### PR TITLE
preventing buggy loop optimization

### DIFF
--- a/libsrc/ismrmrd.cpp
+++ b/libsrc/ismrmrd.cpp
@@ -1055,7 +1055,11 @@ template <typename T> const size_t NDArray<T>::getDataSize() {
 template <typename T> const size_t NDArray<T>::getNumberOfElements() {
     size_t num = 1;
     for (int n = 0; n < arr.ndim; n++) {
-        num *= arr.dims[n];
+        size_t v = arr.dims[n];
+        // This is necessary to prevent bad GCC loop optimization!
+        if (v > 0) {
+            num *= v;
+        }
     }
     return num;
 }


### PR DESCRIPTION
this prevents a general protection fault caused by what appears to be
bad loop optimization by GCC 4.6.3 on Ubuntu 12 in NDArray::getNumberOfElements()