### PR TITLE
Diverse bug fixes and patches

### DIFF
--- a/include/ismrmrd/ismrmrd.h
+++ b/include/ismrmrd/ismrmrd.h
@@ -22,12 +22,14 @@
 /* Language and cross platform section for defining types */
 /* integers */
 #ifdef _MSC_VER /* MS compiler */
+#ifndef HAS_INT_TYPE
 typedef __int16 int16_t;
 typedef unsigned __int16 uint16_t;
 typedef __int32 int32_t;
 typedef unsigned __int32 uint32_t;
 typedef __int64 int64_t;
 typedef unsigned __int64 uint64_t;
+#endif
 #else /* non MS C or C++ compiler */
 #include <stdint.h>
 #include <stddef.h>     /* for size_t */

--- a/include/ismrmrd/ismrmrd.h
+++ b/include/ismrmrd/ismrmrd.h
@@ -367,6 +367,7 @@ EXPORTISMRMRD size_t ismrmrd_size_of_ndarray_data(const ISMRMRD_NDArray *arr);
  */
 EXPORTISMRMRD bool ismrmrd_is_flag_set(const uint64_t flags, const uint64_t val);
 EXPORTISMRMRD int ismrmrd_set_flag(uint64_t *flags, const uint64_t val);
+EXPORTISMRMRD int ismrmrd_set_flags(uint64_t *flags, const uint64_t val);
 EXPORTISMRMRD int ismrmrd_clear_flag(uint64_t *flags, const uint64_t val);
 EXPORTISMRMRD int ismrmrd_clear_all_flags(uint64_t *flags);
 /** @} */
@@ -586,6 +587,10 @@ public:
     void setFlag(const uint64_t val);
     void clearFlag(const uint64_t val);
     void clearAllFlags();
+
+    bool isFlagSet(const FlagBit &val)  { return isFlagSet(val.bitmask_); }
+    void setFlag(const FlagBit &val)    { setFlag(val.bitmask_); }
+    void clearFlag(const FlagBit &val)  { clearFlag(val.bitmask_); }
 
     // Channel mask methods
     bool isChannelActive(uint16_t channel_id);

--- a/include/ismrmrd/ismrmrd.h
+++ b/include/ismrmrd/ismrmrd.h
@@ -530,7 +530,7 @@ public:
 
     // Header, data and trajectory accessors
     const AcquisitionHeader &getHead() const;
-    void setHead(const AcquisitionHeader other);
+    void setHead(const AcquisitionHeader &other);
     
     /**
      * Returns a pointer to the data
@@ -751,7 +751,7 @@ public:
     
     // Attribute string
     void getAttributeString(std::string &atrr) const;
-    void setAttributeString(const std::string attr);
+    void setAttributeString(const std::string &attr);
     size_t getAttributeStringLength() const;
     
     // Data

--- a/include/ismrmrd/ismrmrd.h
+++ b/include/ismrmrd/ismrmrd.h
@@ -538,6 +538,7 @@ public:
      * Returns a pointer to the data
      */
     const complex_float_t * getDataPtr() const;
+    complex_float_t * getDataPtr();
 
     /**
      * Returns a reference to the data
@@ -563,6 +564,7 @@ public:
      * Returns a pointer to the trajectory
      */
     const float * getTrajPtr() const;
+    float * getTrajPtr();
     
     /**
      * Returns a reference to the trajectory
@@ -798,6 +800,7 @@ public:
     void resize(const std::vector<size_t> dimvec);
     size_t getNumberOfElements() const;
     T * getDataPtr();
+    const T * getDataPtr() const;
     
     /** Returns iterator to the beginning of the array **/
     T * begin();

--- a/include/ismrmrd/ismrmrd.h
+++ b/include/ismrmrd/ismrmrd.h
@@ -523,19 +523,19 @@ public:
 
     // Sizes
     void resize(uint16_t num_samples, uint16_t active_channels=1, uint16_t trajectory_dimensions=0);
-    size_t getNumberOfDataElements();
-    size_t getNumberOfTrajElements();
-    size_t getDataSize();
-    size_t getTrajSize();
+    size_t getNumberOfDataElements() const;
+    size_t getNumberOfTrajElements() const;
+    size_t getDataSize() const;
+    size_t getTrajSize() const;
 
     // Header, data and trajectory accessors
-    const AcquisitionHeader &getHead();
+    const AcquisitionHeader &getHead() const;
     void setHead(const AcquisitionHeader other);
     
     /**
      * Returns a pointer to the data
      */
-    const complex_float_t * getDataPtr();
+    const complex_float_t * getDataPtr() const;
 
     /**
      * Returns a reference to the data
@@ -560,7 +560,7 @@ public:
     /**
      * Returns a pointer to the trajectory
      */
-    const float * getTrajPtr();
+    const float * getTrajPtr() const;
     
     /**
      * Returns a reference to the trajectory
@@ -752,7 +752,7 @@ public:
     // Attribute string
     void getAttributeString(std::string &atrr) const;
     void setAttributeString(const std::string attr);
-    size_t getAttributeStringLength();
+    size_t getAttributeStringLength() const;
     
     // Data
     T * getDataPtr();
@@ -786,13 +786,13 @@ public:
     NDArray<T> & operator= (const NDArray<T> &other);
 
     // Accessors and mutators
-    uint16_t getVersion();
-    ISMRMRD_DataTypes getDataType();
-    uint16_t getNDim();
+    uint16_t getVersion() const;
+    ISMRMRD_DataTypes getDataType() const;
+    uint16_t getNDim() const;
     const size_t (&getDims())[ISMRMRD_NDARRAY_MAXDIM];
-    size_t getDataSize();
+    size_t getDataSize() const;
     void resize(const std::vector<size_t> dimvec);
-    size_t getNumberOfElements();
+    size_t getNumberOfElements() const;
     T * getDataPtr();
     
     /** Returns iterator to the beginning of the array **/

--- a/include/ismrmrd/ismrmrd.h
+++ b/include/ismrmrd/ismrmrd.h
@@ -747,6 +747,7 @@ public:
 
     // Header
     ImageHeader & getHead();
+    const ImageHeader & getHead() const;
     void setHead(const ImageHeader& head);
     
     // Attribute string
@@ -756,6 +757,7 @@ public:
     
     // Data
     T * getDataPtr();
+    const T * getDataPtr() const;
     /** Returns the number of elements in the image data **/
     size_t getNumberOfDataElements() const;
     /** Returns the size of the image data in bytes **/

--- a/libsrc/ismrmrd.c
+++ b/libsrc/ismrmrd.c
@@ -485,6 +485,14 @@ int ismrmrd_set_flag(uint64_t *flags, const uint64_t val) {
     return ISMRMRD_NOERROR;
 }
 
+int ismrmrd_set_flags(uint64_t *flags, const uint64_t val) {
+    if (flags==NULL) {
+        return ISMRMRD_PUSH_ERR(ISMRMRD_RUNTIMEERROR, "Pointer should not be NULL.");
+    }
+    *flags = val;
+    return ISMRMRD_NOERROR;
+}
+
 int ismrmrd_clear_flag(uint64_t *flags, const uint64_t val) {
     uint64_t bitmask;
     if (flags==NULL) {

--- a/libsrc/ismrmrd.c
+++ b/libsrc/ismrmrd.c
@@ -426,7 +426,7 @@ size_t ismrmrd_size_of_ndarray_data(const ISMRMRD_NDArray *arr) {
     }
     
     for (n = 0; n < arr->ndim; n++) {
-        num_data *= arr->dims[n];
+        num_data *= (int) (arr->dims[n]);
     }
 
     data_size = num_data * ismrmrd_sizeof_data_type(arr->data_type);
@@ -593,13 +593,13 @@ void ismrmrd_directions_to_quaternion(float read_dir[3], float phase_dir[3],
     
     /* Compute quaternion parameters */
     /* http://www.cs.princeton.edu/~gewang/projects/darth/stuff/quat_faq.html#Q55 */
-    trace = 1.0l + r11 + r22 + r33;
-    if (trace > 0.00001l) { /* simplest case */
+    trace = 1.0 + r11 + r22 + r33;
+    if (trace > 0.00001) { /* simplest case */
         s = sqrt(trace) * 2;
         a = (r32 - r23) / s;
         b = (r13 - r31) / s;
         c = (r21 - r12) / s;
-        d = 0.25l * s;
+        d = 0.25 * s;
     } else {
         /* trickier case...
          * determine which major diagonal element has
@@ -610,7 +610,7 @@ void ismrmrd_directions_to_quaternion(float read_dir[3], float phase_dir[3],
         /* if r11 is the greatest */
         if (xd > 1.0) {
             s = 2.0 * sqrt(xd);
-            a = 0.25l * s;
+            a = 0.25 * s;
             b = (r21 + r12) / s;
             c = (r31 + r13) / s;
             d = (r32 - r23) / s;
@@ -619,7 +619,7 @@ void ismrmrd_directions_to_quaternion(float read_dir[3], float phase_dir[3],
         else if (yd > 1.0) {
             s = 2.0 * sqrt(yd);
             a = (r21 + r12) / s;
-            b = 0.25l * s;
+            b = 0.25 * s;
             c = (r32 + r23) / s;
             d = (r13 - r31) / s;
         }
@@ -628,11 +628,11 @@ void ismrmrd_directions_to_quaternion(float read_dir[3], float phase_dir[3],
             s = 2.0 * sqrt(zd);
             a = (r13 + r31) / s;
             b = (r23 + r32) / s;
-            c = 0.25l * s;
+            c = 0.25 * s;
             d = (r21 - r12) / s;
         }
 
-        if (a < 0.0l) {
+        if (a < 0.0) {
             b = -b;
             c = -c;
             d = -d;

--- a/libsrc/ismrmrd.cpp
+++ b/libsrc/ismrmrd.cpp
@@ -898,6 +898,11 @@ template <typename T> ImageHeader &Image<T>::getHead() {
     return *static_cast<ImageHeader *>(&im.head);
 }
 
+template <typename T> const ImageHeader &Image<T>::getHead() const {
+    // This returns a reference
+    return *static_cast<const ImageHeader *>(&im.head);
+}
+
 template <typename T> void Image<T>::setHead(const ImageHeader &other) {
     if (other.data_type != im.head.data_type) {
         throw std::runtime_error("Cannot assign a header of a different data type.");
@@ -941,6 +946,10 @@ template <typename T> size_t Image<T>::getAttributeStringLength() const
 // Data
 template <typename T> T * Image<T>::getDataPtr() {
      return static_cast<T*>(im.data);
+}
+
+template <typename T> const T * Image<T>::getDataPtr() const {
+     return static_cast<const T*>(im.data);
 }
 
 template <typename T> size_t Image<T>::getNumberOfDataElements() const {

--- a/libsrc/ismrmrd.cpp
+++ b/libsrc/ismrmrd.cpp
@@ -356,7 +356,7 @@ template <typename T> Image<T>::Image(uint16_t matrix_size_x,
     if (ismrmrd_init_image(&im) != ISMRMRD_NOERROR) {
         throw std::runtime_error(build_exception_string());
     }
-    im.head.data_type = get_data_type<T>();
+    im.head.data_type = static_cast<uint16_t>(get_data_type<T>());
     resize(matrix_size_x, matrix_size_y, matrix_size_z, channels);
 }
 
@@ -980,7 +980,7 @@ template <typename T> NDArray<T>::NDArray()
     if (ismrmrd_init_ndarray(&arr) != ISMRMRD_NOERROR) {
         throw std::runtime_error(build_exception_string());
     }
-    arr.data_type = get_data_type<T>();
+    arr.data_type = static_cast<uint16_t>(get_data_type<T>());
 }
 
 template <typename T> NDArray<T>::NDArray(const std::vector<size_t> dimvec)
@@ -988,7 +988,7 @@ template <typename T> NDArray<T>::NDArray(const std::vector<size_t> dimvec)
     if (ismrmrd_init_ndarray(&arr) != ISMRMRD_NOERROR) {
         throw std::runtime_error(build_exception_string());
     }
-    arr.data_type = get_data_type<T>();
+    arr.data_type = static_cast<uint16_t>(get_data_type<T>());
     resize(dimvec);
 }
 
@@ -1050,7 +1050,7 @@ template <typename T> void NDArray<T>::resize(const std::vector<size_t> dimvec) 
     if (dimvec.size() > ISMRMRD_NDARRAY_MAXDIM) {
         throw std::runtime_error("Input vector dimvec is too long.");
     }
-    arr.ndim = dimvec.size();
+    arr.ndim = static_cast<uint16_t>(dimvec.size());
     for (int n=0; n<arr.ndim; n++) {
         arr.dims[n] = dimvec[n];
     }

--- a/libsrc/ismrmrd.cpp
+++ b/libsrc/ismrmrd.cpp
@@ -880,6 +880,10 @@ template <typename T> void Image<T>::setFlag(const uint64_t val) {
     ismrmrd_set_flag(&(im.head.flags), val);
 }
 
+template <typename T> void Image<T>::setFlags(const uint64_t val) {
+    ismrmrd_set_flags(&(im.head.flags), val);
+}
+
 template <typename T> void Image<T>::clearFlag(const uint64_t val) {
     ismrmrd_clear_flag(&(im.head.flags), val);
 }

--- a/libsrc/ismrmrd.cpp
+++ b/libsrc/ismrmrd.cpp
@@ -248,6 +248,10 @@ const complex_float_t * Acquisition::getDataPtr() const {
     return acq.data;
 }
 
+complex_float_t * Acquisition::getDataPtr() {
+    return acq.data;
+}
+
 void Acquisition::setData(complex_float_t * data) {
     memcpy(acq.data,data,this->getNumberOfDataElements()*sizeof(complex_float_t));
 }
@@ -258,6 +262,10 @@ complex_float_t & Acquisition::data(uint16_t sample, uint16_t channel){
 }
 
 const float * Acquisition::getTrajPtr() const {
+    return acq.traj;
+}
+
+float * Acquisition::getTrajPtr() {
     return acq.traj;
 }
 
@@ -1069,6 +1077,10 @@ template <typename T> void NDArray<T>::resize(const std::vector<size_t> dimvec) 
 }
 
 template <typename T> T * NDArray<T>::getDataPtr() {
+    return static_cast<T*>(arr.data);
+}
+
+template <typename T> const T * NDArray<T>::getDataPtr() const {
     return static_cast<T*>(arr.data);
 }
 

--- a/libsrc/ismrmrd.cpp
+++ b/libsrc/ismrmrd.cpp
@@ -958,7 +958,7 @@ template <typename T> size_t Image<T>::getNumberOfDataElements() const {
     num *= im.head.matrix_size[1];
     num *= im.head.matrix_size[2];
     num *= im.head.channels;
-    return ismrmrd_size_of_image_data(&im);
+    return num;
 }
 
 template <typename T> size_t Image<T>::getDataSize() const {

--- a/libsrc/ismrmrd.cpp
+++ b/libsrc/ismrmrd.cpp
@@ -202,30 +202,30 @@ float (&Acquisition::user_float()) [ISMRMRD_USER_FLOATS] {
 }
 
 // Sizes
-size_t Acquisition::getNumberOfDataElements() {
+size_t Acquisition::getNumberOfDataElements() const {
     size_t num = acq.head.number_of_samples * acq.head.active_channels;
     return num;
 }
 
-size_t Acquisition::getDataSize() {
+size_t Acquisition::getDataSize() const {
     size_t num = acq.head.number_of_samples * acq.head.active_channels;
     return num*sizeof(complex_float_t);
 }
 
-size_t Acquisition::getNumberOfTrajElements() {
+size_t Acquisition::getNumberOfTrajElements() const {
     size_t num = acq.head.number_of_samples * acq.head.trajectory_dimensions;
     return num;
 }
 
-size_t Acquisition::getTrajSize() {
+size_t Acquisition::getTrajSize() const {
     size_t num = acq.head.number_of_samples * acq.head.trajectory_dimensions;
     return num*sizeof(float);
 }
 
 // Data and Trajectory accessors
-const AcquisitionHeader & Acquisition::getHead() {
+const AcquisitionHeader & Acquisition::getHead() const {
     // This returns a reference
-    return *static_cast<AcquisitionHeader *>(&acq.head);
+    return *static_cast<const AcquisitionHeader *>(&acq.head);
 }
 
 void Acquisition::setHead(const AcquisitionHeader other) {
@@ -244,7 +244,7 @@ void Acquisition::resize(uint16_t num_samples, uint16_t active_channels, uint16_
        }
 }
 
-const complex_float_t * Acquisition::getDataPtr() {
+const complex_float_t * Acquisition::getDataPtr() const {
     return acq.data;
 }
 
@@ -257,7 +257,7 @@ complex_float_t & Acquisition::data(uint16_t sample, uint16_t channel){
        return acq.data[index];
 }
 
-const float * Acquisition::getTrajPtr() {
+const float * Acquisition::getTrajPtr() const {
     return acq.traj;
 }
 
@@ -923,7 +923,7 @@ template <typename T> void Image<T>::setAttributeString(const std::string attr)
     strcpy(im.attribute_string, attr.c_str());
 }
 
-template <typename T> size_t Image<T>::getAttributeStringLength()
+template <typename T> size_t Image<T>::getAttributeStringLength() const
 {
     return im.head.attribute_string_len;
 }
@@ -1020,15 +1020,15 @@ template <typename T> NDArray<T> & NDArray<T>::operator= (const NDArray<T> &othe
     return *this;
 }
 
-template <typename T> uint16_t NDArray<T>::getVersion() {
+template <typename T> uint16_t NDArray<T>::getVersion() const {
     return arr.version;
 };
 
-template <typename T> ISMRMRD_DataTypes NDArray<T>::getDataType() {
+template <typename T> ISMRMRD_DataTypes NDArray<T>::getDataType() const {
     return static_cast<ISMRMRD_DataTypes>( arr.data_type );
 }
 
-template <typename T> uint16_t NDArray<T>::getNDim() {
+template <typename T> uint16_t NDArray<T>::getNDim() const {
     return  arr.ndim;
 };
     
@@ -1053,11 +1053,11 @@ template <typename T> T * NDArray<T>::getDataPtr() {
     return static_cast<T*>(arr.data);
 }
 
-template <typename T> size_t NDArray<T>::getDataSize() {
+template <typename T> size_t NDArray<T>::getDataSize() const {
     return ismrmrd_size_of_ndarray_data(&arr);
 }
 
-template <typename T> size_t NDArray<T>::getNumberOfElements() {
+template <typename T> size_t NDArray<T>::getNumberOfElements() const {
     size_t num = 1;
     for (int n = 0; n < arr.ndim; n++) {
         size_t v = arr.dims[n];

--- a/utilities/CMakeLists.txt
+++ b/utilities/CMakeLists.txt
@@ -20,7 +20,7 @@ if (NOT WIN32)
   install(TARGETS ismrmrd_test_xml DESTINATION bin)
 endif(NOT WIN32)
 
-find_package(Boost COMPONENTS program_options)
+find_package(Boost 1.43 COMPONENTS program_options)
 find_package(FFTW3 COMPONENTS single)
 
 if(FFTW3_FOUND AND Boost_FOUND)


### PR DESCRIPTION
This pull request includes a number of patches for diverse issues. I can split the request if that is desired.

1. Added const declaration to methods that are constant.
2. Fixed incorrect getNumberOfDataElements() method.
3. Added missing Image<T>::setFlags() method and also added methods that accept const FlagBit & arguments for setting flags.
4. Changed some by value methods to by const reference and fixed some bugs in get/setAttributeString for Image<T>
5. Added ability to disable int typedefs to allow use when typedefs are already provided, e.g. a previous typedef short int16_t  is incompatible with a second typedef __int16 int16_t.
6. Set a minimum boost version of 1.43 as I was unable to compile with earlier versions.
7. Added some explicit casts to suppress compiler warnings.
