### PR TITLE
For upstream

### DIFF
--- a/include/ismrmrd/ismrmrd.h
+++ b/include/ismrmrd/ismrmrd.h
@@ -755,8 +755,10 @@ public:
     void setHead(const ImageHeader& head);
     
     // Attribute string
-    void getAttributeString(std::string &atrr) const;
+    void getAttributeString(std::string &attr) const;
+    const char *getAttributeString() const;
     void setAttributeString(const std::string &attr);
+    void setAttributeString(const char *attr);
     size_t getAttributeStringLength() const;
     
     // Data

--- a/libsrc/ismrmrd.c
+++ b/libsrc/ismrmrd.c
@@ -268,10 +268,13 @@ int ismrmrd_make_consistent_image(ISMRMRD_Image *im) {
    
     attr_size = ismrmrd_size_of_image_attribute_string(im);
     if (attr_size > 0) {
-        im->attribute_string = (char *)realloc(im->attribute_string, attr_size);
+        // Allocate space plus a null-terminating character
+        im->attribute_string = (char *)realloc(im->attribute_string, attr_size+sizeof(*im->attribute_string));
         if (im->attribute_string == NULL) {
             return ISMRMRD_PUSH_ERR(ISMRMRD_MEMORYERROR, "Failed to realloc image attribute string");
         }
+        // Set the null terminating character
+        im->attribute_string[im->head.attribute_string_len] = '\0';
     }
         
     data_size = ismrmrd_size_of_image_data(im);

--- a/libsrc/ismrmrd.cpp
+++ b/libsrc/ismrmrd.cpp
@@ -943,16 +943,20 @@ template <typename T> void Image<T>::setAttributeString(const std::string &attr)
 
 template <typename T> void Image<T>::setAttributeString(const char *attr)
 {
-    size_t length = strlen(attr);
-    im.head.attribute_string_len = static_cast<uint32_t>(length);
+    // Get the length and include the null terminating character
+    size_t length = strlen(attr) + 1;
 
-    // Add null terminating character
-    length++;
-
-    im.attribute_string = (char *)realloc(im.attribute_string, length);
-    if (NULL==im.attribute_string) {
+    // Allocate space and check for success
+    char *newPointer = (char *)realloc(im.attribute_string, length);
+    if (NULL==newPointer) {
         throw std::runtime_error(build_exception_string());
     }
+
+    // Make changes only if reallocation was successful
+    im.attribute_string = newPointer;
+    im.head.attribute_string_len = static_cast<uint32_t>(length);
+
+    // Copy the string
     strncpy(im.attribute_string, attr, length);
 }
 

--- a/libsrc/ismrmrd.cpp
+++ b/libsrc/ismrmrd.cpp
@@ -931,9 +931,19 @@ template <typename T> void Image<T>::getAttributeString(std::string &attr) const
       attr.assign("");
 }
 
+template <typename T> const char *Image<T>::getAttributeString() const
+{
+   return im.attribute_string;
+}
+
 template <typename T> void Image<T>::setAttributeString(const std::string &attr)
 {
-    size_t length = attr.length();
+    this->setAttributeString(attr.c_str());
+}
+
+template <typename T> void Image<T>::setAttributeString(const char *attr)
+{
+    size_t length = strlen(attr);
     im.head.attribute_string_len = static_cast<uint32_t>(length);
 
     // Add null terminating character
@@ -943,7 +953,7 @@ template <typename T> void Image<T>::setAttributeString(const std::string &attr)
     if (NULL==im.attribute_string) {
         throw std::runtime_error(build_exception_string());
     }
-    strncpy(im.attribute_string, attr.c_str(), length);
+    strncpy(im.attribute_string, attr, length);
 }
 
 template <typename T> size_t Image<T>::getAttributeStringLength() const

--- a/libsrc/ismrmrd.cpp
+++ b/libsrc/ismrmrd.cpp
@@ -943,11 +943,11 @@ template <typename T> void Image<T>::setAttributeString(const std::string &attr)
 
 template <typename T> void Image<T>::setAttributeString(const char *attr)
 {
-    // Get the length and include the null terminating character
-    size_t length = strlen(attr) + 1;
+    // Get the string length
+    size_t length = strlen(attr);
 
-    // Allocate space and check for success
-    char *newPointer = (char *)realloc(im.attribute_string, length);
+    // Allocate space plus a null terminator and check for success
+    char *newPointer = (char *)realloc(im.attribute_string, (length+1) * sizeof(*im.attribute_string));
     if (NULL==newPointer) {
         throw std::runtime_error(build_exception_string());
     }
@@ -956,7 +956,8 @@ template <typename T> void Image<T>::setAttributeString(const char *attr)
     im.attribute_string = newPointer;
     im.head.attribute_string_len = static_cast<uint32_t>(length);
 
-    // Copy the string
+    // Set the null terminator and copy the string
+    im.attribute_string[length] = '\0';
     strncpy(im.attribute_string, attr, length);
 }
 


### PR DESCRIPTION
Added ```const char *``` accessors for ```Image<T>``` attribute string to simplify copying to/from ```char *``` by avoiding creation of intermediate ```std::string``` copy.

Added missing Dataset::readImage instantiations and Boost include for tests.