### PR TITLE
fixed deserialize bug, casting long int to int

### DIFF
--- a/libsrc/xml.cpp
+++ b/libsrc/xml.cpp
@@ -222,7 +222,7 @@ namespace ISMRMRD
 	throw std::runtime_error("experimentalConditions not defined in ismrmrdHeader");
       } else {
 	ExperimentalConditions e;
-	e.H1resonanceFrequency_Hz = std::atoi(experimentalConditions.child_value("H1resonanceFrequency_Hz"));
+	e.H1resonanceFrequency_Hz = std::atol(experimentalConditions.child_value("H1resonanceFrequency_Hz"));
 	h.experimentalConditions = e;
       }
       


### PR DESCRIPTION
fix deserializing h1resonance integer overflow.
caused by *atoi* is used for casting strings to *int. Changed to [atol](http://www.cplusplus.com/reference/cstdlib/atol/).