### PR TITLE
fixing memory leaks detected in ismrmrd_c_example

### DIFF
--- a/examples/c/main.c
+++ b/examples/c/main.c
@@ -45,12 +45,9 @@ int main(void)
     ismrmrd_write_header(&dataset1, xmlhdr);
 
     /* Append some acquisitions */
-    /* must initialize an acquisition before you can use it */
-    ismrmrd_init_acquisition(&acq);
     nacq_write = 5;
     for (n=0; n < nacq_write; n++) {
-        /* must free an acquisition before you can reinitialize it */
-        ismrmrd_init_acquisition(&acq);
+        /* must initialize an acquisition before you can use it */
         ismrmrd_init_acquisition(&acq);
         acq.head.number_of_samples = 128;
         acq.head.active_channels = 4;
@@ -76,6 +73,7 @@ int main(void)
             ismrmrd_set_flag(&(acq.head.flags), ISMRMRD_ACQ_LAST_IN_SLICE);
         }
         ismrmrd_append_acquisition(&dataset1, &acq);
+        ismrmrd_cleanup_acquisition(&acq);
     }
     
     /* Close the dataset */
@@ -91,6 +89,7 @@ int main(void)
     /* Read the header */
     xmlstring = ismrmrd_read_header(&dataset2);
     printf("Header: %s\n", xmlstring);
+    free(xmlstring);
 
     /* Get the number of acquisitions */
     nacq_read = ismrmrd_get_number_of_acquisitions(&dataset2);
@@ -131,6 +130,8 @@ int main(void)
 #else
     printf("Data 3: %f\t 2: %f\n", creal(acq3.data[4]), creal(acq2.data[4]));
 #endif
+    ismrmrd_cleanup_acquisition(&acq2);
+    ismrmrd_cleanup_acquisition(&acq3);
 
     /* Create and store an image */
     ismrmrd_init_image(&im);
@@ -152,6 +153,7 @@ int main(void)
         ((float*)im.data)[loc] = 2.0;
     }
     ismrmrd_append_image(&dataset2, "testimages", &im);
+    ismrmrd_cleanup_image(&im);
 
     numim = ismrmrd_get_number_of_images(&dataset2, "testimages");
     printf("Number of images stored = %d\n", numim);
@@ -160,6 +162,7 @@ int main(void)
     ismrmrd_read_image(&dataset2, "testimages", 1, &im2);
     printf("Image 1 attribute string = %s\n", im2.attribute_string);
     printf("Image 1 at position 10 has value = %f\n", ((float*)im2.data)[10]);
+    ismrmrd_cleanup_image(&im2);
 
     /* Create and store an array */
     ismrmrd_init_ndarray(&arr);
@@ -174,19 +177,14 @@ int main(void)
     }
     ismrmrd_append_array(&dataset2, "testarray", &arr);
     printf("Number of arrays stored = %d\n", ismrmrd_get_number_of_arrays(&dataset2, "testarray"));
+    ismrmrd_cleanup_ndarray(&arr);
 
     /* Read it back in */
     ismrmrd_init_ndarray(&arr2);
     ismrmrd_read_array(&dataset2, "testarray", 0, &arr2);
     printf("Array 2 at position 10 has value = %f\n", ((float*)arr2.data)[10]);
+    ismrmrd_cleanup_ndarray(&arr2);
     
-    /* Clean up */
-    /* This frees the internal memory of the acquisitions */
-    ismrmrd_cleanup_acquisition(&acq);
-    ismrmrd_cleanup_acquisition(&acq2);
-    ismrmrd_cleanup_acquisition(&acq3);
-    free(xmlstring);
-
     /* Close the dataset */
     ismrmrd_close_dataset(&dataset2);
 

--- a/libsrc/ismrmrd.c
+++ b/libsrc/ismrmrd.c
@@ -269,7 +269,7 @@ int ismrmrd_make_consistent_image(ISMRMRD_Image *im) {
     attr_size = ismrmrd_size_of_image_attribute_string(im);
     if (attr_size > 0) {
         // Allocate space plus a null-terminating character
-        im->attribute_string = (char *)realloc(im->attribute_string, attr_size+sizeof(*im->attribute_string));
+        im->attribute_string = (char *)realloc(im->attribute_string, attr_size + sizeof(*im->attribute_string));
         if (im->attribute_string == NULL) {
             return ISMRMRD_PUSH_ERR(ISMRMRD_MEMORYERROR, "Failed to realloc image attribute string");
         }


### PR DESCRIPTION
This fixes memory leaks in both the C example and the dataset portion of the library. See below the output of `valgrind --dsymutil=yes --leak-check=full` on OS X before and after these changes:

Before
```
==44114== 
==44114== HEAP SUMMARY:
==44114==     in use at exit: 20,503,080 bytes in 437 blocks
==44114==   total heap usage: 7,270 allocs, 6,833 frees, 59,767,459 bytes allocated
==44114== 
==44114== 14 bytes in 1 blocks are definitely lost in loss record 3 of 91
==44114==    at 0x10000A4BB: malloc (in /usr/local/Cellar/valgrind/HEAD/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==44114==    by 0x10005C698: make_path (dataset.c:87)
==44114==    by 0x10005DAD9: ismrmrd_read_acquisition (dataset.c:1155)
==44114==    by 0x100002599: main (main.c:109)
==44114== 
==44114== 32 bytes in 1 blocks are definitely lost in loss record 28 of 91
==44114==    at 0x10000A4BB: malloc (in /usr/local/Cellar/valgrind/HEAD/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==44114==    by 0x10005F38C: get_array_properties (dataset.c:731)
==44114==    by 0x10005F1AD: ismrmrd_read_array (dataset.c:1432)
==44114==    by 0x100002A78: main (main.c:180)
==44114== 
==44114== 38 bytes in 1 blocks are definitely lost in loss record 30 of 91
==44114==    at 0x10000A4BB: malloc (in /usr/local/Cellar/valgrind/HEAD/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==44114==    by 0x1002EE4EB: H5T_vlen_str_mem_write (in /usr/local/Cellar/hdf5/1.8.14/lib/libhdf5.9.dylib)
==44114==    by 0x10028F8D0: H5T__conv_vlen (in /usr/local/Cellar/hdf5/1.8.14/lib/libhdf5.9.dylib)
==44114==    by 0x100284344: H5T_convert (in /usr/local/Cellar/hdf5/1.8.14/lib/libhdf5.9.dylib)
==44114==    by 0x100181F17: H5D__scatgath_read (in /usr/local/Cellar/hdf5/1.8.14/lib/libhdf5.9.dylib)
==44114==    by 0x10017243C: H5D__contig_read (in /usr/local/Cellar/hdf5/1.8.14/lib/libhdf5.9.dylib)
==44114==    by 0x10017E564: H5D__read (in /usr/local/Cellar/hdf5/1.8.14/lib/libhdf5.9.dylib)
==44114==    by 0x10017DFA6: H5Dread (in /usr/local/Cellar/hdf5/1.8.14/lib/libhdf5.9.dylib)
==44114==    by 0x10005CA1F: ismrmrd_read_header (dataset.c:1041)
==44114==    by 0x1000024CC: main (main.c:92)
==44114== 
==44114== 48 bytes in 1 blocks are definitely lost in loss record 36 of 91
==44114==    at 0x10000A4BB: malloc (in /usr/local/Cellar/valgrind/HEAD/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==44114==    by 0x10001404D: ismrmrd_make_consistent_image (ismrmrd.c:272)
==44114==    by 0x100002799: main (main.c:144)
==44114== 
==44114== 48 bytes in 1 blocks are definitely lost in loss record 37 of 91
==44114==    at 0x10000A4BB: malloc (in /usr/local/Cellar/valgrind/HEAD/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==44114==    by 0x10001404D: ismrmrd_make_consistent_image (ismrmrd.c:272)
==44114==    by 0x10005EBEE: ismrmrd_read_image (dataset.c:1310)
==44114==    by 0x100002919: main (main.c:160)
==44114== 
==44114== 48 bytes in 1 blocks are definitely lost in loss record 38 of 91
==44114==    at 0x10000A4BB: malloc (in /usr/local/Cellar/valgrind/HEAD/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==44114==    by 0x1002EE4EB: H5T_vlen_str_mem_write (in /usr/local/Cellar/hdf5/1.8.14/lib/libhdf5.9.dylib)
==44114==    by 0x10028F8D0: H5T__conv_vlen (in /usr/local/Cellar/hdf5/1.8.14/lib/libhdf5.9.dylib)
==44114==    by 0x100284344: H5T_convert (in /usr/local/Cellar/hdf5/1.8.14/lib/libhdf5.9.dylib)
==44114==    by 0x100181F17: H5D__scatgath_read (in /usr/local/Cellar/hdf5/1.8.14/lib/libhdf5.9.dylib)
==44114==    by 0x100169EA7: H5D__chunk_read (in /usr/local/Cellar/hdf5/1.8.14/lib/libhdf5.9.dylib)
==44114==    by 0x10017E564: H5D__read (in /usr/local/Cellar/hdf5/1.8.14/lib/libhdf5.9.dylib)
==44114==    by 0x10017DFA6: H5Dread (in /usr/local/Cellar/hdf5/1.8.14/lib/libhdf5.9.dylib)
==44114==    by 0x10005BA1A: read_element (dataset.c:813)
==44114==    by 0x10005EC30: ismrmrd_read_image (dataset.c:1315)
==44114==    by 0x100002919: main (main.c:160)
==44114== 
==44114== 16,384 bytes in 4 blocks are definitely lost in loss record 87 of 91
==44114==    at 0x10000A4BB: malloc (in /usr/local/Cellar/valgrind/HEAD/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==44114==    by 0x100013952: ismrmrd_make_consistent_acquisition (ismrmrd.c:145)
==44114==    by 0x100002337: main (main.c:60)
==44114== 
==44114== 524,288 bytes in 1 blocks are definitely lost in loss record 88 of 91
==44114==    at 0x10000A4BB: malloc (in /usr/local/Cellar/valgrind/HEAD/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==44114==    by 0x100014831: ismrmrd_make_consistent_ndarray (ismrmrd.c:408)
==44114==    by 0x1000029AB: main (main.c:171)
==44114== 
==44114== 3,145,728 bytes in 1 blocks are definitely lost in loss record 89 of 91
==44114==    at 0x10000A4BB: malloc (in /usr/local/Cellar/valgrind/HEAD/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==44114==    by 0x100014831: ismrmrd_make_consistent_ndarray (ismrmrd.c:408)
==44114==    by 0x10005F1C9: ismrmrd_read_array (dataset.c:1436)
==44114==    by 0x100002A78: main (main.c:180)
==44114== 
==44114== 8,388,608 bytes in 1 blocks are definitely lost in loss record 90 of 91
==44114==    at 0x10000A4BB: malloc (in /usr/local/Cellar/valgrind/HEAD/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==44114==    by 0x1000140E3: ismrmrd_make_consistent_image (ismrmrd.c:282)
==44114==    by 0x100002799: main (main.c:144)
==44114== 
==44114== 8,388,608 bytes in 1 blocks are definitely lost in loss record 91 of 91
==44114==    at 0x10000A4BB: malloc (in /usr/local/Cellar/valgrind/HEAD/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==44114==    by 0x1000140E3: ismrmrd_make_consistent_image (ismrmrd.c:282)
==44114==    by 0x10005EBEE: ismrmrd_read_image (dataset.c:1310)
==44114==    by 0x100002919: main (main.c:160)
==44114== 
==44114== LEAK SUMMARY:
==44114==    definitely lost: 20,463,844 bytes in 14 blocks
==44114==    indirectly lost: 0 bytes in 0 blocks
==44114==      possibly lost: 0 bytes in 0 blocks
==44114==    still reachable: 148 bytes in 3 blocks
==44114==         suppressed: 39,088 bytes in 420 blocks
==44114== Reachable blocks (those to which a pointer was found) are not shown.
==44114== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==44114== 
==44114== For counts of detected and suppressed errors, rerun with: -v
==44114== ERROR SUMMARY: 11 errors from 11 contexts (suppressed: 13 from 13)
```

After:
```
==44387== 
==44387== HEAP SUMMARY:
==44387==     in use at exit: 39,236 bytes in 423 blocks
==44387==   total heap usage: 7,269 allocs, 6,846 frees, 60,291,709 bytes allocated
==44387== 
==44387== LEAK SUMMARY:
==44387==    definitely lost: 0 bytes in 0 blocks
==44387==    indirectly lost: 0 bytes in 0 blocks
==44387==      possibly lost: 0 bytes in 0 blocks
==44387==    still reachable: 148 bytes in 3 blocks
==44387==         suppressed: 39,088 bytes in 420 blocks
==44387== Reachable blocks (those to which a pointer was found) are not shown.
==44387== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==44387== 
==44387== For counts of detected and suppressed errors, rerun with: -v
==44387== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 13 from 13)
```