### PR TITLE
add a member function to show whether meta container is empty or not

### DIFF
--- a/include/ismrmrd/meta.h
+++ b/include/ismrmrd/meta.h
@@ -238,7 +238,12 @@ namespace ISMRMRD
       }
       return it->second[index];
     }
-    
+
+    bool empty()
+    {
+        return map_.empty();
+    }
+
   protected:
     map_t map_; 
   };


### PR DESCRIPTION
Add a member function to show entire meta container is empty or not. 
Sometime it is required to know this status to avoid further checking every attribute.