### PR TITLE
Icp2

### DIFF
--- a/examples/protocol/main.cpp
+++ b/examples/protocol/main.cpp
@@ -12,226 +12,243 @@
 using boost::asio::ip::tcp;
 namespace po = boost::program_options;
 
-class Server {
-public:
-    Server(boost::asio::io_service& io_service, unsigned short port)//const tcp::endpoint& endpoint)
-      : io_service_(io_service),
-        port_(port)
-    { }
+class Server
+{
+  public:
 
-    void start()
+  Server (boost::asio::io_service& io_service, unsigned short port)
+  : io_service_(io_service),
+    port_(port)
+  {}
+
+  void start()
+  {
+    tcp::acceptor acceptor(io_service_, tcp::endpoint(tcp::v4(), port_));
+    while (true)
     {
-        tcp::acceptor acceptor(io_service_, tcp::endpoint(tcp::v4(), port_));
-        while (true) {
-            tcp::socket sock(io_service_);
-            acceptor.accept(sock);
-            /* session(std::move(sock)); */
-            std::thread(&Server::session, this, std::move(sock)).detach();
-        }
+      tcp::socket sock(io_service_);
+      acceptor.accept(sock);
+      // session(std::move(sock));
+      std::thread(&Server::session, this, std::move(sock)).detach();
+    }
+  }
+
+  void session (tcp::socket sock)
+  {
+    uint32_t xml_size = 0;
+    std::string xml;
+
+    boost::system::error_code error;
+
+    // First, read the XML header's size in bytes, then the actual header
+    boost::asio::read(sock, boost::asio::buffer(&xml_size, sizeof(xml_size)), error);
+    xml.resize(xml_size);
+    boost::asio::read(sock, boost::asio::buffer(&xml[0], xml_size), error);
+
+    ISMRMRD::IsmrmrdHeader xmlHeader;
+    ISMRMRD::deserialize(xml.c_str(), xmlHeader);
+
+    std::map<int, std::vector<ISMRMRD::Acquisition<float> > > streams;
+
+    while (true)
+    {
+      // Read identifier of next object
+      uint32_t etype = 0;
+      boost::asio::read(sock, boost::asio::buffer(&etype, sizeof(etype)), error);
+
+      // TODO: handle more dataTypes
+      if (etype != ISMRMRD::ISMRMRD_MRACQUISITION)
+      {
+        throw std::runtime_error("unsupported dataType ID received by server");
+      }
+
+      // Read the Acquisition header
+      ISMRMRD::AcquisitionHeader head;
+      boost::asio::read(sock, boost::asio::buffer(&head, sizeof(head)), error);
+
+      // Create Acquisition and set its header to allocate memory for its data buffer
+      ISMRMRD::Acquisition<float> acq;
+      acq.setHead(head);
+
+      // Read the acquisition data
+      //size_t nbytes = acq.getNumberOfDataElements() * sizeof_storage_type(acq.getStorageType());
+      //boost::asio::read(sock, boost::asio::buffer(acq.getDataPtr(), nbytes), error);
+
+      // Read the acquisition trajectory
+      std::vector<float> traj(head.number_of_samples * head.trajectory_dimensions);
+      boost::asio::read(sock, boost::asio::buffer(traj), error);
+      acq.setTraj(traj);
+
+      //if (streams.count (head.ent_head.stream) == 0)
+      if (streams.count (ISMRMRD::ISMRMRD_MRACQUISITION_STREAM) == 0)
+      {
+        std::vector<ISMRMRD::Acquisition<float> > stream;
+        stream.push_back(acq);
+        streams[ISMRMRD::ISMRMRD_MRACQUISITION_STREAM] = stream;
+        //streams[head.ent_head.stream] = stream;
+      }
+      else
+      {
+        streams[ISMRMRD::ISMRMRD_MRACQUISITION_STREAM].push_back(acq);
+        //streams[head.ent_head.stream].push_back(acq);
+      }
     }
 
-    void session(tcp::socket sock)
+    std::map<int, std::vector<ISMRMRD::Acquisition<float> > >::const_iterator it;
+    for (it = streams.begin(); it != streams.end(); ++it)
     {
-        uint32_t xml_size = 0;
-        std::string xml;
-
-        boost::system::error_code error;
-
-        // First, read the XML header's size in bytes, then the actual header
-        boost::asio::read(sock, boost::asio::buffer(&xml_size, sizeof(xml_size)), error);
-        xml.resize(xml_size);
-        boost::asio::read(sock, boost::asio::buffer(&xml[0], xml_size), error);
-
-        ISMRMRD::IsmrmrdHeader xmlHeader;
-        ISMRMRD::deserialize(xml.c_str(), xmlHeader);
-
-        std::map<int, std::vector<ISMRMRD::Acquisition<float> > > streams;
-
-        while (true) {
-            // Read identifier of next object
-            uint32_t etype = 0;
-            boost::asio::read(sock, boost::asio::buffer(&etype, sizeof(etype)), error);
-
-            // TODO: handle more dataTypes
-            if (etype != ISMRMRD::ISMRMRD_MRACQUISITION) {
-                throw std::runtime_error("unsupported dataType ID received by server");
-            }
-
-            // Read the Acquisition header
-            ISMRMRD::AcquisitionHeader head;
-            boost::asio::read(sock, boost::asio::buffer(&head, sizeof(head)), error);
-
-            // Create Acquisition and set its header to allocate memory for its data buffer
-            ISMRMRD::Acquisition<float> acq;
-            acq.setHead(head);
-
-            // Read the acquisition data
-            //size_t nbytes = acq.getNumberOfDataElements() * sizeof_storage_type(acq.getStorageType());
-            //boost::asio::read(sock, boost::asio::buffer(acq.getDataPtr(), nbytes), error);
-
-            // Read the acquisition trajectory
-            std::vector<float> traj(head.number_of_samples * head.trajectory_dimensions);
-            boost::asio::read(sock, boost::asio::buffer(traj), error);
-            acq.setTraj(traj);
-
-            if (streams.count (head.ent_head.stream) == 0)
-            {
-              std::vector<ISMRMRD::Acquisition<float> > stream;
-              stream.push_back(acq);
-              streams[head.ent_head.stream] = stream;
-            }
-            else
-            {
-              streams[head.ent_head.stream].push_back(acq);
-            }
-        }
-
-        std::map<int, std::vector<ISMRMRD::Acquisition<float> > >::const_iterator it;
-        for (it = streams.begin(); it != streams.end(); ++it) {
-            std::cout << "Stream #" << it->first << " contains " << it->second.size() << " acquisitions\n";
-        }
-
-
-        //if (error == boost::asio::error::eof) {
-            //return;
-        //} else if (error) {
-            //throw boost::system::system_error(error);
-        //}
-
-
-        /* boost::asio::write(sock, boost::asio::buffer(rev), error); */
-        /* if (error) { */
-        /*     throw boost::system::system_error(error); */
-        /* } */
+      std::cout << "Stream #" << it->first << " contains "
+                << it->second.size() << " acquisitions\n";
     }
 
-private:
-    boost::asio::io_service& io_service_;
-    unsigned short port_;
-    /* tcp::acceptor acceptor_; */
-    /* tcp::socket socket_; */
+
+    //if (error == boost::asio::error::eof)
+    //{
+      //return;
+    //}
+    //else if (error)
+    //{
+      //throw boost::system::system_error(error);
+    //}
+
+
+    // boost::asio::write(sock, boost::asio::buffer(rev), error);
+    // if (error)
+    // {
+    //   throw boost::system::system_error(error);
+    // }
+  }
+
+  private:
+
+  boost::asio::io_service& io_service_;
+  unsigned short port_;
+  // tcp::acceptor acceptor_;
+  // tcp::socket socket_;
 };
 
-/* class Client { */
-/* public: */
-/*     Client(boost::asio::io_service& io_service, const tcp::endpoint& endpoint) */
-/*       : io_service_(io_service), */
-/*         socket_(io_service) */
-/*     { */
-/*         std::cout << "Creating client...\n"; */
-/*         do_connect(endpoint); */
-/*     } */
+// class Client
+// {
+// public:
+//     Client(boost::asio::io_service& io_service, const tcp::endpoint& endpoint)
+//       : io_service_(io_service),
+//         socket_(io_service)
+//     {
+//         std::cout << "Creating client...\n";
+//         do_connect(endpoint);
+//     }
 
-/*     void send_dataset(const ISMRMRD::Dataset& dataset) */
-/*     { */
-/*         io_service_.post( */
-/*     } */
+//     void send_dataset(const ISMRMRD::Dataset& dataset)
+//     {
+//         io_service_.post(
+//     }
 
-/*     void close() */
-/*     { */
-/*         std::cout << "Closing client...\n"; */
-/*         io_service_.post([this]() { socket_.close(); }); */
-/*     } */
+//     void close()
+//     {
+//         std::cout << "Closing client...\n";
+//         io_service_.post([this]() { socket_.close(); });
+//     }
 
-/* private: */
-/*     void do_connect(tcp::endpoint endpoint) */
-/*     { */
-/*         std::cout << "Client do_connect...\n"; */
-/*         socket_.async_connect(endpoint, */
-/*             [this](boost::system::error_code ec) */
-/*             { */
-/*                 if (!ec) { */
-/*                     std::cout << "connected to server\n"; */
-/*                 } */
-/*             }); */
-/*     } */
+// private:
+//     void do_connect(tcp::endpoint endpoint)
+//     {
+//         std::cout << "Client do_connect...\n";
+//         socket_.async_connect(endpoint,
+//             [this](boost::system::error_code ec)
+//             {
+//                 if (!ec) {
+//                     std::cout << "connected to server\n";
+//                 }
+//             });
+//     }
 
-/*     boost::asio::io_service& io_service_; */
-/*     tcp::socket socket_; */
-/* }; */
+//     boost::asio::io_service& io_service_;
+//     tcp::socket socket_;
+// };
 
 void start_server(unsigned short port)
 {
-    boost::asio::io_service io_service;
-    Server server(io_service, port);
-    server.start();
+  boost::asio::io_service io_service;
+  Server server(io_service, port);
+  server.start();
 }
 
 int main(int argc, char* argv[])
 {
-    unsigned short port = 9999;
-    std::string in_fname, out_fname("out.h5");
-    std::string in_hdf5_group("/dataset"), out_hdf5_group("/dataset");
+  unsigned short port = 9999;
+  std::string in_fname, out_fname("out.h5");
+  std::string in_hdf5_group("/dataset"), out_hdf5_group("/dataset");
 
-    po::options_description desc("Allowed options");
-    desc.add_options()
-      ("help,h", "produce help message")
-      ("port,p", po::value<unsigned short>(&port)->default_value(port), "TCP port for server")
-      ("filename,f", po::value<std::string>(&in_fname), "Input file")
-      ("outfile,o", po::value<std::string>(&out_fname)->default_value(out_fname), "Output file")
-      ("in-group,g", po::value<std::string>(&in_hdf5_group)->default_value(in_hdf5_group), "Input group name")
-      ("out-group,G", po::value<std::string>(&out_hdf5_group)->default_value(out_hdf5_group), "Output group name")
-    ;
+  po::options_description desc("Allowed options");
+  desc.add_options()
+    ("help,h", "produce help message")
+    ("port,p", po::value<unsigned short>(&port)->default_value(port), "TCP port for server")
+    ("filename,f", po::value<std::string>(&in_fname), "Input file")
+    ("outfile,o", po::value<std::string>(&out_fname)->default_value(out_fname), "Output file")
+    ("in-group,g", po::value<std::string>(&in_hdf5_group)->default_value(in_hdf5_group), "Input group name")
+    ("out-group,G", po::value<std::string>(&out_hdf5_group)->default_value(out_hdf5_group), "Output group name")
+  ;
 
-    po::variables_map vm;
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
+  po::variables_map vm;
+  po::store(po::parse_command_line(argc, argv, desc), vm);
+  po::notify(vm);
 
-    if (vm.count("help")) {
-        std::cout << desc << "\n";
-        return 0;
+  if (vm.count("help")) {
+    std::cout << desc << "\n";
+    return 0;
+  }
+
+  if (!vm.count("filename")) {
+    std::cerr << "You must supply an input filename\n";
+    return 1;
+  }
+
+  // start the "server" in the background and detach so it dies when the program exits
+  std::thread(start_server, port).detach();
+
+  sleep(1);
+
+  // Open dataset
+  ISMRMRD::Dataset dataset(in_fname.c_str(), in_hdf5_group.c_str());
+
+  // Read and deserialize XML header
+  std::string xml = dataset.readHeader();
+  ISMRMRD::IsmrmrdHeader xmlHeader;
+  ISMRMRD::deserialize(xml.c_str(), xmlHeader);
+
+  // Establish connection to server
+  boost::asio::io_service io_service;
+  tcp::socket sock(io_service);
+  tcp::endpoint endpoint(boost::asio::ip::address::from_string("127.0.0.1"), port);
+  sock.connect(endpoint);
+
+  // First, send the XML header
+  uint32_t xml_size = xml.size();
+  boost::asio::write(sock, boost::asio::buffer(&xml_size, sizeof(xml_size)));
+  boost::asio::write(sock, boost::asio::buffer(xml));
+
+  for (size_t i = 0; i < dataset.getNumberOfAcquisitions(); ++i) {
+    ISMRMRD::Acquisition<float> acq = dataset.readAcquisition<float>(i);
+
+    // send the acquisition type (acquisition or waveform)
+    // TODO: do we care if its an MR acquisition or just waveform data?
+    uint32_t etype = ISMRMRD::ISMRMRD_MRACQUISITION;
+    boost::asio::write(sock, boost::asio::buffer(&etype, sizeof(etype)));
+
+    // send the acquisition header
+    ISMRMRD::AcquisitionHeader head = acq.getHead();
+    boost::asio::write(sock, boost::asio::buffer(&head, sizeof(head)));
+
+    // send the acquisition data
+    //boost::asio::write(sock, boost::asio::buffer(acq.getDataPtr(), acq.getNumberOfDataElements() * sizeof_storage_type(acq.getStorageType())));
+
+    // send the acquisition trajectory
+    std::vector<float> traj = acq.getTraj();
+    if (traj.size() > 0)
+    {
+      boost::asio::write(sock, boost::asio::buffer(traj));
     }
-
-    if (!vm.count("filename")) {
-        std::cerr << "You must supply an input filename\n";
-        return 1;
-    }
-
-    // start the "server" in the background and detach so it dies when the program exits
-    std::thread(start_server, port).detach();
-
-    sleep(1);
-
-    // Open dataset
-    ISMRMRD::Dataset dataset(in_fname.c_str(), in_hdf5_group.c_str());
-
-    // Read and deserialize XML header
-    std::string xml = dataset.readHeader();
-    ISMRMRD::IsmrmrdHeader xmlHeader;
-    ISMRMRD::deserialize(xml.c_str(), xmlHeader);
-
-    // Establish connection to server
-    boost::asio::io_service io_service;
-    tcp::socket sock(io_service);
-    tcp::endpoint endpoint(boost::asio::ip::address::from_string("127.0.0.1"), port);
-    sock.connect(endpoint);
-
-    // First, send the XML header
-    uint32_t xml_size = xml.size();
-    boost::asio::write(sock, boost::asio::buffer(&xml_size, sizeof(xml_size)));
-    boost::asio::write(sock, boost::asio::buffer(xml));
-
-    for (size_t i = 0; i < dataset.getNumberOfAcquisitions(); ++i) {
-        ISMRMRD::Acquisition<float> acq = dataset.readAcquisition<float>(i);
-
-        // send the acquisition type (acquisition or waveform)
-        // TODO: do we care if its an MR acquisition or just waveform data?
-        uint32_t etype = ISMRMRD::ISMRMRD_MRACQUISITION;
-        boost::asio::write(sock, boost::asio::buffer(&etype, sizeof(etype)));
-
-        // send the acquisition header
-        ISMRMRD::AcquisitionHeader head = acq.getHead();
-        boost::asio::write(sock, boost::asio::buffer(&head, sizeof(head)));
-
-        // send the acquisition data
-        //boost::asio::write(sock, boost::asio::buffer(acq.getDataPtr(), acq.getNumberOfDataElements() * sizeof_storage_type(acq.getStorageType())));
-
-        // send the acquisition trajectory
-        std::vector<float> traj = acq.getTraj();
-        if (traj.size() > 0) {
-            boost::asio::write(sock, boost::asio::buffer(traj));
-        }
-    }
+  }
 
 
     return 0;

--- a/include/ismrmrd/dataset.h
+++ b/include/ismrmrd/dataset.h
@@ -16,55 +16,80 @@ using namespace H5;
 namespace ISMRMRD {
 
 //  ISMRMRD Dataset C++ Interface
-class EXPORTISMRMRD Dataset {
-public:
-    // Constructor and destructor
-    Dataset(const std::string& filename, const std::string& groupname,
-            bool create_file_if_needed=true, bool read_only=false);
-    ~Dataset();
+class EXPORTISMRMRD Dataset
+{
+  public:
+  // Constructor and destructor
+  Dataset (const std::string& filename,
+           const std::string& groupname,
+           bool create_file_if_needed = true,
+           bool read_only             = false);
+  ~Dataset();
 
-    // XML Header
-    void writeHeader(const std::string &xmlstring);
-    std::string readHeader();
+  // XML Header
+  void writeHeader (const std::string &xmlstring);
+  std::string readHeader();
 
-    // Acquisitions
-    template <typename T> void appendAcquisition(const Acquisition<T>& acq, int stream_number=-1);
-    template <typename T> Acquisition<T> readAcquisition(unsigned long index, int stream_number=-1);
-    unsigned long getNumberOfAcquisitions(int stream_number=-1);
+  // Acquisitions
+  template <typename T>
+  void appendAcquisition (const Acquisition<T>& acq,
+                          int stream_number = -1);
+  template <typename T>
+  Acquisition<T> readAcquisition (unsigned long index,
+                                  int stream_number = -1);
 
-    // Images
-    template <typename T> void appendImage(const std::string &var, const Image<T> &im);
-    template <typename T> Image<T> readImage(const std::string &var, unsigned long index);
-    unsigned long getNumberOfImages(const std::string &var);
+  unsigned long getNumberOfAcquisitions(int stream_number = -1);
 
-    // NDArrays
-    template <typename T> void appendNDArray(const std::string &var, const NDArray<T> &arr);
-    template <typename T> NDArray<T> readNDArray(const std::string &var, unsigned long index);
-    unsigned long getNumberOfNDArrays(const std::string &var);
+  // Images
+  template <typename T>
+  void appendImage (const std::string &var,
+                    const Image<T> &im);
+  template <typename T>
+  Image<T> readImage (const std::string &var,
+                      unsigned long index);
 
-protected:
-    bool linkExists(const std::string& path);
-    void createGroup(const std::string& path);
-    std::string constructDataPath(unsigned int stream_number);
-    size_t appendToDataSet(const std::string& path, const DataType& dtype,
-            const std::vector<hsize_t>& dims, void* data);
-    void readFromDataSet(const std::string& path, const DataType& dtype,
-            const std::vector<hsize_t>& entry_dims, size_t index, void* data);
+  unsigned long getNumberOfImages (const std::string &var);
+
+  // NDArrays
+  template <typename T>
+  void appendNDArray (const std::string &var,
+                      const NDArray<T> &arr);
+  template <typename T>
+  NDArray<T> readNDArray (const std::string &var,
+                          unsigned long index);
+
+  unsigned long getNumberOfNDArrays (const std::string &var);
+
+  protected:
+
+  bool linkExists (const std::string& path);
+  void createGroup (const std::string& path);
+  std::string constructDataPath (unsigned int stream_number);
+  size_t appendToDataSet (const std::string& path,
+                          const DataType& dtype,
+                          const std::vector<hsize_t>& dims,
+                          void* data);
+
+  void readFromDataSet (const std::string& path,
+                        const DataType& dtype,
+                        const std::vector<hsize_t>& entry_dims,
+                        size_t index,
+                        void* data);
 
 
-    std::string filename_;
-    std::string groupname_;
-    std::string xml_header_path_;
-    std::string data_path_;
-    std::string index_path_;
+  std::string filename_;
+  std::string groupname_;
+  std::string xml_header_path_;
+  std::string data_path_;
+  std::string index_path_;
 
-    std::map<std::string, DataSet> datasets_;
+  std::map<std::string, DataSet> datasets_;
 
-    bool read_only_;
-    bool file_open_;
-    bool dataset_open_;
+  bool read_only_;
+  bool file_open_;
+  bool dataset_open_;
 
-    H5File file_;
+  H5File file_;
 };
 
 } /* namespace ISMRMRD */

--- a/include/ismrmrd/dataset_dtypes.h
+++ b/include/ismrmrd/dataset_dtypes.h
@@ -12,177 +12,254 @@
 
 namespace ISMRMRD {
 
-
-template <typename T> struct AcquisitionHeader_with_data
+/******************************************************************************/
+template <typename T>
+struct AcquisitionHeader_with_data
 {
-    AcquisitionHeader head;
-    hvl_t traj;
-    hvl_t data;
+  AcquisitionHeader head;
+  hvl_t traj;
+  hvl_t data;
 };
 
-template <typename T> struct ImageHeader_with_data
+/******************************************************************************/
+/* Can't use thi format - the image wil not be viewable 
+template <typename T>
+struct ImageHeader_with_data
 {
-	ImageHeader head;
-	hvl_t data;
+ 	ImageHeader head;
+ 	hvl_t data;
 };
+*/
 
+/******************************************************************************/
 struct IndexEntry
 {
-    uint32_t stream;
-    uint32_t index;
+  uint32_t stream;
+  uint32_t index;
 };
 
+/******************************************************************************/
 template <typename T>
 DataType get_hdf5_data_type();
 
-template <> DataType get_hdf5_data_type<IndexEntry>()
+/******************************************************************************/
+template <>
+DataType get_hdf5_data_type<IndexEntry>()
 {
-    CompType dtype(sizeof(IndexEntry));
+  CompType dtype (sizeof (IndexEntry));
 
-    dtype.insertMember("stream", HOFFSET(IndexEntry, stream), PredType::NATIVE_UINT32);
-    dtype.insertMember("index", HOFFSET(IndexEntry, index), PredType::NATIVE_UINT32);
-
-    return dtype;
+  dtype.insertMember ("stream", HOFFSET (IndexEntry, stream),
+                      PredType::NATIVE_UINT32);
+  dtype.insertMember ("index", HOFFSET (IndexEntry, index),
+                      PredType::NATIVE_UINT32);
+  return dtype;
 }
 
-template <> DataType get_hdf5_data_type<EncodingCounters>()
+/******************************************************************************/
+template <>
+DataType get_hdf5_data_type<EncodingCounters>()
 {
-    CompType dtype(sizeof(EncodingCounters));
+  CompType dtype (sizeof (EncodingCounters));
 
-    dtype.insertMember("kspace_encode_step_0", HOFFSET(EncodingCounters, kspace_encode_step_0), PredType::NATIVE_UINT32);
-    dtype.insertMember("kspace_encode_step_1", HOFFSET(EncodingCounters, kspace_encode_step_1), PredType::NATIVE_UINT32);
-    dtype.insertMember("kspace_encode_step_2", HOFFSET(EncodingCounters, kspace_encode_step_2), PredType::NATIVE_UINT32);
-    dtype.insertMember("average", HOFFSET(EncodingCounters, average), PredType::NATIVE_UINT32);
-    dtype.insertMember("slice", HOFFSET(EncodingCounters, slice), PredType::NATIVE_UINT32);
-    dtype.insertMember("contrast", HOFFSET(EncodingCounters, contrast), PredType::NATIVE_UINT32);
-    dtype.insertMember("phase", HOFFSET(EncodingCounters, phase), PredType::NATIVE_UINT32);
-    dtype.insertMember("repetition", HOFFSET(EncodingCounters, repetition), PredType::NATIVE_UINT32);
-    dtype.insertMember("set", HOFFSET(EncodingCounters, set), PredType::NATIVE_UINT32);
-    dtype.insertMember("segment", HOFFSET(EncodingCounters, segment), PredType::NATIVE_UINT32);
+  dtype.insertMember ("kspace_encode_step_0",
+                      HOFFSET (EncodingCounters, kspace_encode_step_0),
+                      PredType::NATIVE_UINT32);
+  dtype.insertMember ("kspace_encode_step_1",
+                      HOFFSET (EncodingCounters, kspace_encode_step_1),
+                      PredType::NATIVE_UINT32);
+  dtype.insertMember ("kspace_encode_step_2",
+                      HOFFSET (EncodingCounters, kspace_encode_step_2),
+                      PredType::NATIVE_UINT32);
+  dtype.insertMember ("average", HOFFSET (EncodingCounters, average),
+                      PredType::NATIVE_UINT32);
+  dtype.insertMember ("slice", HOFFSET (EncodingCounters, slice),
+                      PredType::NATIVE_UINT32);
+  dtype.insertMember ("contrast", HOFFSET (EncodingCounters, contrast),
+                      PredType::NATIVE_UINT32);
+  dtype.insertMember ("phase", HOFFSET (EncodingCounters, phase),
+                      PredType::NATIVE_UINT32);
+  dtype.insertMember ("repetition", HOFFSET (EncodingCounters, repetition),
+                      PredType::NATIVE_UINT32);
+  dtype.insertMember ("set", HOFFSET (EncodingCounters, set),
+                      PredType::NATIVE_UINT32);
+  dtype.insertMember ("segment", HOFFSET (EncodingCounters, segment),
+                      PredType::NATIVE_UINT32);
 
-    std::vector<hsize_t> dims(1, ISMRMRD_USER_INTS);
-    DataType array_type = ArrayType(PredType::NATIVE_UINT32, 1, &dims[0]);
-    dtype.insertMember("user", HOFFSET(EncodingCounters, user), array_type);
-
-    return dtype;
-}
-
-template <> DataType get_hdf5_data_type<AcquisitionHeader>()
-{
-  CompType dtype (sizeof(AcquisitionHeader));
-
-  dtype.insertMember ("stream", HOFFSET(AcquisitionHeader,
-                      ent_head.stream), PredType::NATIVE_UINT32);
-  dtype.insertMember ("signature", HOFFSET(AcquisitionHeader,
-                      ent_head.signature), PredType::NATIVE_UINT32);
-  dtype.insertMember ("entity_type", HOFFSET(AcquisitionHeader,
-                      ent_head.entity_type), PredType::NATIVE_UINT32);
-  dtype.insertMember ("storage_type", HOFFSET(AcquisitionHeader,
-                      ent_head.storage_type), PredType::NATIVE_UINT32);
-
-  dtype.insertMember("time_stamp", HOFFSET(AcquisitionHeader, time_stamp),  PredType::NATIVE_UINT64);
-  dtype.insertMember("flags",  HOFFSET(AcquisitionHeader, flags),  PredType::NATIVE_UINT64);
-  dtype.insertMember("scan_counter",  HOFFSET(AcquisitionHeader, scan_counter),  PredType::NATIVE_UINT32);
-
-  std::vector<hsize_t> dims(1, ISMRMRD_PHYS_STAMPS);
-  DataType array_type = ArrayType(PredType::NATIVE_UINT32, 1, &dims[0]);
-  dtype.insertMember("physiology_time_stamp", HOFFSET(AcquisitionHeader, physiology_time_stamp), array_type);
-  dtype.insertMember("number_of_samples",  HOFFSET(AcquisitionHeader, number_of_samples),  PredType::NATIVE_UINT32);
-  dtype.insertMember("available_channels",  HOFFSET(AcquisitionHeader, available_channels),  PredType::NATIVE_UINT32);
-  dtype.insertMember("active_channels",  HOFFSET(AcquisitionHeader, active_channels),  PredType::NATIVE_UINT32);
-
-  dims[0] = ISMRMRD_CHANNEL_MASKS;
-  DataType mask_array_type = ArrayType(PredType::NATIVE_UINT64, 1, &dims[0]);
-  dtype.insertMember("channel_mask",  HOFFSET(AcquisitionHeader, channel_mask), mask_array_type);
-  dtype.insertMember("discard_pre",  HOFFSET(AcquisitionHeader, discard_pre),  PredType::NATIVE_UINT32);
-  dtype.insertMember("discard_post",  HOFFSET(AcquisitionHeader, discard_post),  PredType::NATIVE_UINT32);
-  dtype.insertMember("center_sample",  HOFFSET(AcquisitionHeader, center_sample),  PredType::NATIVE_UINT32);
-  dtype.insertMember("encoding_space_ref",  HOFFSET(AcquisitionHeader, encoding_space_ref),  PredType::NATIVE_UINT32);
-  dtype.insertMember("trajectory_dimensions", HOFFSET(AcquisitionHeader, trajectory_dimensions),  PredType::NATIVE_UINT32);
-  dtype.insertMember("dwell_time_ns",  HOFFSET(AcquisitionHeader, dwell_time_ns),  PredType::NATIVE_UINT32);
-
-  dims[0] = ISMRMRD_POSITION_LENGTH;
-  DataType position_array_type = ArrayType(PredType::NATIVE_FLOAT, 1, &dims[0]);
-  dtype.insertMember("position",  HOFFSET(AcquisitionHeader, position), position_array_type);
-
-  dims[0] = ISMRMRD_POSITION_LENGTH;
-  DataType read_dir_array_type = ArrayType(PredType::NATIVE_FLOAT, 1, &dims[0]);
-  dtype.insertMember("read_dir",  HOFFSET(AcquisitionHeader, read_dir), read_dir_array_type);
-
-  dims[0] = ISMRMRD_POSITION_LENGTH;
-  DataType phase_dir_array_type = ArrayType(PredType::NATIVE_FLOAT, 1, &dims[0]);
-  dtype.insertMember("phase_dir",  HOFFSET(AcquisitionHeader, phase_dir), phase_dir_array_type);
-
-  dims[0] = ISMRMRD_POSITION_LENGTH;
-  DataType slice_dir_array_type = ArrayType(PredType::NATIVE_FLOAT, 1, &dims[0]);
-  dtype.insertMember("slice_dir",  HOFFSET(AcquisitionHeader, slice_dir), slice_dir_array_type);
-
-  dims[0] = ISMRMRD_POSITION_LENGTH;
-  DataType table_array_type = ArrayType(PredType::NATIVE_FLOAT, 1, &dims[0]);
-  dtype.insertMember("patient_table_position",  HOFFSET(AcquisitionHeader, patient_table_position), table_array_type);
-
-  DataType ec_type = get_hdf5_data_type<EncodingCounters>();
-  dtype.insertMember("idx",  HOFFSET(AcquisitionHeader, idx), ec_type);
-
-  dims[0] = ISMRMRD_USER_INTS;
-  DataType user_int_array_type = ArrayType(PredType::NATIVE_INT32, 1, &dims[0]);
-  dtype.insertMember("user_int",  HOFFSET(AcquisitionHeader, user_int), user_int_array_type);
-
-  dims[0] = ISMRMRD_USER_FLOATS;
-  DataType user_float_array_type = ArrayType(PredType::NATIVE_FLOAT, 1, &dims[0]);
-  dtype.insertMember("user_float",  HOFFSET(AcquisitionHeader, user_float), user_float_array_type);
+  std::vector<hsize_t> dims (1, ISMRMRD_USER_INTS);
+  DataType array_type = ArrayType (PredType::NATIVE_UINT32, 1, &dims[0]);
+  dtype.insertMember ("user", HOFFSET (EncodingCounters, user), array_type);
 
   return dtype;
 }
 
-
-template <> DataType get_hdf5_data_type<AcquisitionHeader_with_data<float> >()
+/******************************************************************************/
+template <>
+DataType get_hdf5_data_type<AcquisitionHeader>()
 {
-    CompType dtype(sizeof(AcquisitionHeader_with_data<float>));
+  CompType dtype (sizeof (AcquisitionHeader));
 
-    DataType head_type = get_hdf5_data_type<AcquisitionHeader>();
+  dtype.insertMember ("time_stamp", HOFFSET (AcquisitionHeader, time_stamp),
+                      PredType::NATIVE_UINT64);
+  dtype.insertMember ("flags",  HOFFSET (AcquisitionHeader, flags),
+                      PredType::NATIVE_UINT64);
+  dtype.insertMember ("scan_counter",  HOFFSET (AcquisitionHeader, scan_counter),
+                      PredType::NATIVE_UINT32);
 
-    DataType realv_type = DataType(H5Tvlen_create(PredType::NATIVE_FLOAT.getId()));
+  std::vector<hsize_t> dims (1, ISMRMRD_PHYS_STAMPS);
+  DataType array_type = ArrayType (PredType::NATIVE_UINT32, 1, &dims[0]);
+  dtype.insertMember ("physiology_time_stamp", HOFFSET (AcquisitionHeader,
+                      physiology_time_stamp), array_type);
+  dtype.insertMember ("number_of_samples",  HOFFSET (AcquisitionHeader,
+                      number_of_samples),  PredType::NATIVE_UINT32);
+  dtype.insertMember ("available_channels",  HOFFSET (AcquisitionHeader,
+                      available_channels),  PredType::NATIVE_UINT32);
+  dtype.insertMember ("active_channels",  HOFFSET (AcquisitionHeader,
+                      active_channels),  PredType::NATIVE_UINT32);
 
-    dtype.insertMember("head", HOFFSET(AcquisitionHeader_with_data<float>, head), head_type);
-    dtype.insertMember("traj", HOFFSET(AcquisitionHeader_with_data<float>, traj), realv_type);
-    dtype.insertMember("data", HOFFSET(AcquisitionHeader_with_data<float>, data), realv_type);
+  dims[0] = ISMRMRD_CHANNEL_MASKS;
+  DataType mask_array_type = ArrayType (PredType::NATIVE_UINT64, 1, &dims[0]);
+  dtype.insertMember ("channel_mask",
+                      HOFFSET (AcquisitionHeader, channel_mask),
+                      mask_array_type);
+  dtype.insertMember ("discard_pre",  HOFFSET (AcquisitionHeader, discard_pre),
+                      PredType::NATIVE_UINT32);
+  dtype.insertMember ("discard_post",
+                      HOFFSET (AcquisitionHeader, discard_post),
+                      PredType::NATIVE_UINT32);
+  dtype.insertMember ("center_sample",
+                      HOFFSET (AcquisitionHeader, center_sample),
+                      PredType::NATIVE_UINT32);
+  dtype.insertMember ("encoding_space_ref",
+                      HOFFSET (AcquisitionHeader, encoding_space_ref),
+                      PredType::NATIVE_UINT32);
+  dtype.insertMember ("trajectory_dimensions",
+                      HOFFSET (AcquisitionHeader, trajectory_dimensions),
+                      PredType::NATIVE_UINT32);
+  dtype.insertMember ("dwell_time_ns",
+                      HOFFSET (AcquisitionHeader, dwell_time_ns),
+                      PredType::NATIVE_UINT32);
 
-    return dtype;
+  dims[0] = ISMRMRD_POSITION_LENGTH;
+  DataType position_array_type =
+    ArrayType (PredType::NATIVE_FLOAT, 1, &dims[0]);
+  dtype.insertMember ("position",  HOFFSET (AcquisitionHeader, position),
+                      position_array_type);
+
+  dims[0] = ISMRMRD_POSITION_LENGTH;
+  DataType read_dir_array_type =
+    ArrayType (PredType::NATIVE_FLOAT, 1, &dims[0]);
+  dtype.insertMember ("read_dir",  HOFFSET (AcquisitionHeader, read_dir),
+                      read_dir_array_type);
+
+  dims[0] = ISMRMRD_POSITION_LENGTH;
+  DataType phase_dir_array_type =
+    ArrayType (PredType::NATIVE_FLOAT, 1, &dims[0]);
+  dtype.insertMember ("phase_dir",  HOFFSET (AcquisitionHeader, phase_dir),
+                      phase_dir_array_type);
+
+  dims[0] = ISMRMRD_POSITION_LENGTH;
+  DataType slice_dir_array_type =
+    ArrayType (PredType::NATIVE_FLOAT, 1, &dims[0]);
+  dtype.insertMember ("slice_dir",  HOFFSET (AcquisitionHeader, slice_dir),
+                      slice_dir_array_type);
+
+  dims[0] = ISMRMRD_POSITION_LENGTH;
+  DataType table_array_type = ArrayType (PredType::NATIVE_FLOAT, 1, &dims[0]);
+  dtype.insertMember ("patient_table_position",
+                      HOFFSET (AcquisitionHeader, patient_table_position),
+                      table_array_type);
+
+  DataType ec_type = get_hdf5_data_type<EncodingCounters>();
+  dtype.insertMember ("idx",  HOFFSET (AcquisitionHeader, idx), ec_type);
+
+  dims[0] = ISMRMRD_USER_INTS;
+  DataType user_int_array_type = ArrayType (PredType::NATIVE_INT32, 1, &dims[0]);
+  dtype.insertMember ("user_int",  HOFFSET (AcquisitionHeader, user_int),
+                      user_int_array_type);
+
+  dims[0] = ISMRMRD_USER_FLOATS;
+  DataType user_float_array_type =
+    ArrayType (PredType::NATIVE_FLOAT, 1, &dims[0]);
+  dtype.insertMember ("user_float",  HOFFSET (AcquisitionHeader, user_float),
+                      user_float_array_type);
+
+  return dtype;
 }
 
-template <> DataType get_hdf5_data_type<AcquisitionHeader_with_data<int16_t> >()
+/******************************************************************************/
+template <>
+DataType get_hdf5_data_type<AcquisitionHeader_with_data<float> >()
 {
-    CompType dtype(sizeof(AcquisitionHeader_with_data<int16_t>));
+  CompType dtype (sizeof (AcquisitionHeader_with_data<float>));
+  DataType head_type = get_hdf5_data_type<AcquisitionHeader>();
 
-    DataType head_type = get_hdf5_data_type<AcquisitionHeader>();
+  DataType realv_type =
+    DataType (H5Tvlen_create (PredType::NATIVE_FLOAT.getId()));
 
-    DataType realv_float_type = DataType(H5Tvlen_create(PredType::NATIVE_FLOAT.getId()));
-    DataType realv_int_type = DataType(H5Tvlen_create(PredType::NATIVE_INT16.getId()));
-
-    dtype.insertMember("head", HOFFSET(AcquisitionHeader_with_data<int16_t>, head), head_type);
-    dtype.insertMember("traj", HOFFSET(AcquisitionHeader_with_data<int16_t>, traj), realv_float_type);
-    dtype.insertMember("data", HOFFSET(AcquisitionHeader_with_data<int16_t>, data), realv_int_type);
-
-    return dtype;
+  dtype.insertMember ("head",
+                      HOFFSET (AcquisitionHeader_with_data<float>, head),
+                      head_type);
+  dtype.insertMember ("traj",
+                      HOFFSET (AcquisitionHeader_with_data<float>, traj),
+                      realv_type);
+  dtype.insertMember ("data",
+                      HOFFSET (AcquisitionHeader_with_data<float>, data),
+                      realv_type);
+  return dtype;
 }
 
-template <> DataType get_hdf5_data_type<AcquisitionHeader_with_data<int32_t> >()
+/******************************************************************************/
+template <>
+DataType get_hdf5_data_type<AcquisitionHeader_with_data<int16_t> >()
 {
-    CompType dtype(sizeof(AcquisitionHeader_with_data<int32_t>));
+  CompType dtype (sizeof (AcquisitionHeader_with_data<int16_t>));
 
-    DataType head_type = get_hdf5_data_type<AcquisitionHeader>();
+  DataType head_type = get_hdf5_data_type<AcquisitionHeader>();
 
-    DataType realv_float_type = DataType(H5Tvlen_create(PredType::NATIVE_FLOAT.getId()));
-    DataType realv_int_type = DataType(H5Tvlen_create(PredType::NATIVE_INT32.getId()));
+  DataType realv_float_type =
+    DataType (H5Tvlen_create (PredType::NATIVE_FLOAT.getId()));
+  DataType realv_int_type =
+    DataType (H5Tvlen_create (PredType::NATIVE_INT16.getId()));
 
-    dtype.insertMember("head", HOFFSET(AcquisitionHeader_with_data<int32_t>, head), head_type);
-    dtype.insertMember("traj", HOFFSET(AcquisitionHeader_with_data<int32_t>, traj), realv_float_type);
-    dtype.insertMember("data", HOFFSET(AcquisitionHeader_with_data<int32_t>, data), realv_int_type);
-
-    return dtype;
+  dtype.insertMember ("head",
+                      HOFFSET (AcquisitionHeader_with_data<int16_t>, head),
+                      head_type);
+  dtype.insertMember ("traj",
+                      HOFFSET (AcquisitionHeader_with_data<int16_t>, traj),
+                      realv_float_type);
+  dtype.insertMember ("data",
+                      HOFFSET (AcquisitionHeader_with_data<int16_t>, data),
+                      realv_int_type);
+  return dtype;
 }
 
+/******************************************************************************/
+template <>
+DataType get_hdf5_data_type<AcquisitionHeader_with_data<int32_t> >()
+{
+  CompType dtype (sizeof (AcquisitionHeader_with_data<int32_t>));
+
+  DataType head_type = get_hdf5_data_type<AcquisitionHeader>();
+
+  DataType realv_float_type =
+    DataType (H5Tvlen_create (PredType::NATIVE_FLOAT.getId()));
+  DataType realv_int_type =
+    DataType (H5Tvlen_create (PredType::NATIVE_INT32.getId()));
+
+  dtype.insertMember ("head",
+                      HOFFSET (AcquisitionHeader_with_data<int32_t>, head),
+                      head_type);
+  dtype.insertMember ("traj",
+                      HOFFSET (AcquisitionHeader_with_data<int32_t>, traj),
+                      realv_float_type);
+  dtype.insertMember ("data",
+                      HOFFSET (AcquisitionHeader_with_data<int32_t>, data),
+                      realv_int_type);
+
+  return dtype;
+}
+
+/******************************************************************************/
 } // namespace ISMRMRD
 
 #endif // ISMRMRD_DATASET_DTYPES_H

--- a/include/ismrmrd/ismrmrd.h
+++ b/include/ismrmrd/ismrmrd.h
@@ -52,29 +52,46 @@ enum Constant {
 };
 
 /** Storage Types */
-enum StorageType {
-    ISMRMRD_CHAR = 0,     /**< corresponds to char           */
-    ISMRMRD_USHORT = 1,   /**< corresponds to uint16_t       */
-    ISMRMRD_SHORT = 2,    /**< corresponds to int16_t        */
-    ISMRMRD_UINT = 3,     /**< corresponds to uint32_t       */
-    ISMRMRD_INT = 4,      /**< corresponds to int32_t        */
-    ISMRMRD_ULONG = 5,    /**< corresponds to uint64_t       */
-    ISMRMRD_LONG = 6,     /**< corresponds to int64_t        */
-    ISMRMRD_FLOAT = 7,    /**< corresponds to float          */
-    ISMRMRD_DOUBLE = 8,   /**< corresponds to double         */
-    ISMRMRD_CXFLOAT = 9,  /**< corresponds to complex float  */
-    ISMRMRD_CXDOUBLE = 10 /**< corresponds to complex double */
+enum StorageType
+{
+  ISMRMRD_STORAGE_NONE =  0, /**< No data present to specify storage */
+  ISMRMRD_CHAR         =  1, /**< corresponds to char                */
+  ISMRMRD_USHORT       =  2, /**< corresponds to uint16_t            */
+  ISMRMRD_SHORT        =  3, /**< corresponds to int16_t             */
+  ISMRMRD_UINT         =  4, /**< corresponds to uint32_t            */
+  ISMRMRD_INT          =  5, /**< corresponds to int32_t             */
+  ISMRMRD_ULONG        =  6, /**< corresponds to uint64_t            */
+  ISMRMRD_LONG         =  7, /**< corresponds to int64_t             */
+  ISMRMRD_FLOAT        =  8, /**< corresponds to float               */
+  ISMRMRD_DOUBLE       =  9, /**< corresponds to double              */
+  ISMRMRD_CXFLOAT      = 10, /**< corresponds to complex float       */
+  ISMRMRD_CXDOUBLE     = 11  /**< corresponds to complex double      */
 };
 
-enum EntityType {
-    ISMRMRD_HANDSHAKE = 0,     /**< first package sent                    */
-    ISMRMRD_COMMAND = 1,       /**< commands used to control recon system */
-    ISMRMRD_MRACQUISITION = 2, /**< MR raw data                           */
-    ISMRMRD_WAVEFORM = 3,      /**< Gradient, physiology, etc. waveform   */
-    ISMRMRD_IMAGE = 4,         /**< Reconstructed image                   */
-    ISMRMRD_XML_HEADER = 5,    /**< The XML header describing the data    */
-    ISMRMRD_ERROR = 6,         /**< Something went wrong                  */
-    ISMRMRD_BLOB = 7           /**< Some binary object, with description  */
+enum EntityType
+{
+  ISMRMRD_ENTITY_TYPE_ERROR =  0,  /**< Unassigned value                     */
+  ISMRMRD_HANDSHAKE         =  1,  /**< first package sent                   */
+  ISMRMRD_COMMAND           =  2,  /**< commands to control recon system     */
+  ISMRMRD_MRACQUISITION     =  3,  /**< MR raw data                          */
+  ISMRMRD_WAVEFORM          =  4,  /**< Gradient, physiology, etc.           */
+  ISMRMRD_IMAGE             =  5,  /**< Reconstructed image                  */
+  ISMRMRD_XML_HEADER        =  6,  /**< XML header describing the data       */
+  ISMRMRD_ERROR             =  7,  /**< Something went wrong                 */
+  ISMRMRD_BLOB              =  8   /**< Some binary object, with description */
+};
+
+enum StreamId
+{
+  ISMRMRD_STREAM_INVALID        =  0,
+  ISMRMRD_HEADER_STREAM         =  1,
+  ISMRMRD_HANDSHAKE_STREAM      =  2,
+  ISMRMRD_COMMAND_STREAM        =  3,
+  ISMRMRD_ERROR_STREAM          =  4,
+  ISMRMRD_MRACQUISITION_STREAM  =  5,
+  ISMRMRD_IMAGE_STREAM          =  6,
+  ISMRMRD_WAVEFORM_STREAM       =  7,
+  ISMRMRD_BLOB_STREAM           =  8
 };
 
 /** Acquisition Flags */
@@ -170,28 +187,28 @@ struct AcquisitionHeader
 {
   EntityHeader ent_head;
 
-  uint64_t time_stamp;                                  /**< Experiment time stamp - in nano seconds */
-  uint64_t flags;                                       /**< bit field with flags */
-  uint32_t scan_counter;                                /**< Current acquisition number in the measurement */
+  uint64_t time_stamp;                        /**< Experiment time stamp - in nano seconds */
+  uint64_t flags;                             /**< bit field with flags */
+  uint32_t scan_counter;                      /**< Current acquisition number in the measurement */
   uint32_t physiology_time_stamp[ISMRMRD_PHYS_STAMPS];  /**< Physiology time stamps, e.g. ecg, breating, etc. */
-  uint32_t number_of_samples;                           /**< Number of samples acquired */
-  uint32_t available_channels;                          /**< Available coils */
-  uint32_t active_channels;                             /**< Active coils on current acquisiton */
-  uint64_t channel_mask[ISMRMRD_CHANNEL_MASKS];         /**< Mask to indicate which channels are active. Support for 1024 channels */
-  uint32_t discard_pre;                                 /**< Samples to be discarded at the beginning of  acquisition */
-  uint32_t discard_post;                                /**< Samples to be discarded at the end of acquisition */
-  uint32_t center_sample;                               /**< Sample at the center of k-space */
-  uint32_t encoding_space_ref;                          /**< Reference to an encoding space, typically only one per acquisition */
-  uint32_t trajectory_dimensions;                       /**< Indicates the dimensionality of the trajectory vector (0 means no trajectory) */
-  uint32_t dwell_time_ns;                               /**< Time between samples in nano seconds, sampling BW */
-  float position[ISMRMRD_POSITION_LENGTH];              /**< Three-dimensional spatial offsets from isocenter */
-  float read_dir[ISMRMRD_DIRECTION_LENGTH];             /**< Directional cosines of the readout/frequency encoding */
-  float phase_dir[ISMRMRD_DIRECTION_LENGTH];            /**< Directional cosines of the phase */
-  float slice_dir[ISMRMRD_DIRECTION_LENGTH];            /**< Directional cosines of the slice direction */
-  float patient_table_position[ISMRMRD_POSITION_LENGTH];/**< Patient table off-center */
-  EncodingCounters idx;                                 /**< Encoding loop counters, see above */
-  int32_t user_int[ISMRMRD_USER_INTS];                  /**< Free user parameters */
-  float user_float[ISMRMRD_USER_FLOATS];                /**< Free user parameters */
+  uint32_t number_of_samples;                 /**< Number of samples acquired */
+  uint32_t available_channels;                /**< Available coils */
+  uint32_t active_channels;                   /**< Active coils on current acquisiton */
+  uint64_t channel_mask[ISMRMRD_CHANNEL_MASKS]; /**< Mask to indicate which channels are active. Support for 1024 channels */
+  uint32_t discard_pre;                       /**< Samples to be discarded at the beginning of  acquisition */
+  uint32_t discard_post;                      /**< Samples to be discarded at the end of acquisition */
+  uint32_t center_sample;                     /**< Sample at the center of k-space */
+  uint32_t encoding_space_ref;                /**< Reference to an encoding space, typically only one per acquisition */
+  uint32_t trajectory_dimensions;             /**< Indicates the dimensionality of the trajectory vector (0 means no trajectory) */
+  uint32_t dwell_time_ns;                     /**< Time between samples in nano seconds, sampling BW */
+  float position[ISMRMRD_POSITION_LENGTH];    /**< Three-dimensional spatial offsets from isocenter */
+  float read_dir[ISMRMRD_DIRECTION_LENGTH];   /**< Directional cosines of the readout/frequency encoding */
+  float phase_dir[ISMRMRD_DIRECTION_LENGTH];  /**< Directional cosines of the phase */
+  float slice_dir[ISMRMRD_DIRECTION_LENGTH];  /**< Directional cosines of the slice direction */
+  float patient_table_position[ISMRMRD_POSITION_LENGTH]; /**< Patient table off-center */
+  EncodingCounters idx;                       /**< Encoding loop counters, see above */
+  int32_t user_int[ISMRMRD_USER_INTS];        /**< Free user parameters */
+  float user_float[ISMRMRD_USER_FLOATS];      /**< Free user parameters */
 };
 
 
@@ -200,29 +217,29 @@ struct ImageHeader
 {
   EntityHeader ent_head;
 
-  uint64_t time_stamp;                                 /**< Experiment time stamp - in nano seconds */
-  uint64_t flags;                                      /**< bit field with flags */
-  uint32_t matrix_size[3];                             /**< Pixels in the 3 spatial dimensions */
-  float field_of_view[3];                              /**< Size (in mm) of the 3 spatial dimensions */
-  uint32_t channels;                                   /**< Number of receive channels */
-  float position[3];                                   /**< Three-dimensional spatial offsets from isocenter */
-  float read_dir[3];                                   /**< Directional cosines of the readout/frequency encoding */
-  float phase_dir[3];                                  /**< Directional cosines of the phase */
-  float slice_dir[3];                                  /**< Directional cosines of the slice direction */
-  float patient_table_position[3];                     /**< Patient table off-center */
-  uint32_t average;                                    /**< e.g. signal average number */
-  uint32_t slice;                                      /**< e.g. imaging slice number */
-  uint32_t contrast;                                   /**< e.g. echo number in multi-echo */
-  uint32_t phase;                                      /**< e.g. cardiac phase number */
-  uint32_t repetition;                                 /**< e.g. dynamic number for dynamic scanning */
-  uint32_t set;                                        /**< e.g. flow encodning set */
+  uint64_t time_stamp;                       /**< Experiment time stamp - in nano seconds */
+  uint64_t flags;                            /**< bit field with flags */
+  uint32_t matrix_size[3];                   /**< Pixels in the 3 spatial dimensions */
+  float field_of_view[3];                    /**< Size (in mm) of the 3 spatial dimensions */
+  uint32_t channels;                         /**< Number of receive channels */
+  float position[ISMRMRD_POSITION_LENGTH];   /**< Three-dimensional spatial offsets from isocenter */
+  float read_dir[ISMRMRD_DIRECTION_LENGTH];  /**< Directional cosines of the readout/frequency encoding */
+  float phase_dir[ISMRMRD_DIRECTION_LENGTH]; /**< Directional cosines of the phase */
+  float slice_dir[ISMRMRD_DIRECTION_LENGTH]; /**< Directional cosines of the slice direction */
+  float patient_table_position[ISMRMRD_POSITION_LENGTH]; /**< Patient table off-center */
+  uint32_t average;                          /**< e.g. signal average number */
+  uint32_t slice;                            /**< e.g. imaging slice number */
+  uint32_t contrast;                         /**< e.g. echo number in multi-echo */
+  uint32_t phase;                            /**< e.g. cardiac phase number */
+  uint32_t repetition;                       /**< e.g. dynamic number for dynamic scanning */
+  uint32_t set;                              /**< e.g. flow encodning set */
   uint32_t physiology_time_stamp[ISMRMRD_PHYS_STAMPS]; /**< Physiology time stamps, e.g. ecg, breathing, etc. */
-  uint32_t image_type;                                 /**< e.g. magnitude, phase, complex, real, imag, etc. */
-  uint32_t image_index;                                /**< e.g. image number in series of images */
-  uint32_t image_series_index;                         /**< e.g. series number */
-  int32_t user_int[ISMRMRD_USER_INTS];                 /**< Free user parameters */
-  float user_float[ISMRMRD_USER_FLOATS];               /**< Free user parameters */
-  uint32_t attribute_string_len;                       /**< Length of attributes string */
+  uint32_t image_type;                       /**< e.g. magnitude, phase, complex, real, imag, etc. */
+  uint32_t image_index;                      /**< e.g. image number in series of images */
+  uint32_t image_series_index;               /**< e.g. series number */
+  int32_t user_int[ISMRMRD_USER_INTS];       /**< Free user parameters */
+  float user_float[ISMRMRD_USER_FLOATS];     /**< Free user parameters */
+  uint32_t attribute_string_len;             /**< Length of attributes string */
 };
 
 #pragma pack(pop) /* Restore old alignment */
@@ -243,6 +260,7 @@ class EXPORTISMRMRD Entity
 
   virtual uint32_t    getStream ()      const = 0;
   virtual uint32_t    getSignature ()   const = 0;
+  virtual uint32_t    getVersion ()     const = 0;
   virtual EntityType  getEntityType ()  const = 0;
   virtual StorageType getStorageType () const = 0;
 
@@ -419,6 +437,7 @@ class EXPORTISMRMRD Acquisition
   // Functions inherited from Entity
   virtual uint32_t    getStream ()      const;
   virtual uint32_t    getSignature ()   const;
+  virtual uint32_t    getVersion ()     const;
   virtual EntityType  getEntityType ()  const;
   virtual StorageType getStorageType () const;
   virtual std::vector<unsigned char> serialize();
@@ -584,6 +603,7 @@ class EXPORTISMRMRD Image
   // Functions inherited from Entity
   virtual uint32_t    getStream ()      const;
   virtual uint32_t    getSignature ()   const;
+  virtual uint32_t    getVersion ()     const;
   virtual EntityType  getEntityType ()  const;
   virtual StorageType getStorageType () const;
   virtual std::vector<unsigned char> serialize();
@@ -597,7 +617,80 @@ class EXPORTISMRMRD Image
   std::vector<T> data_;
 };
 
-/// N-Dimensional array type
+/********************************* Waveform ***********************************/
+/******************************************************************************/
+struct WaveformHeader
+{
+  EntityHeader ent_head;
+  uint64_t     begin_time_stamp;  /**< Experiment time stamp in nano seconds */
+  uint64_t     end_time_stamp;    /**< Experiment time stamp in nano seconds */
+  uint32_t     dwell_time_ns;     /**< Time between samples in nano seconds */
+  uint32_t     number_of_samples; /**< Number of samples acquired */
+  int32_t      user_int[ISMRMRD_USER_INTS];     /**< Free user parameters */
+  float        user_float[ISMRMRD_USER_FLOATS]; /**< Free user parameters */
+};
+
+/******************************************************************************/
+bool operator== (const WaveformHeader &h1, const WaveformHeader &h2);
+
+/******************************************************************************/
+class Waveform
+: public Entity
+{
+  public:
+
+  Waveform (uint32_t num_samples = 0);
+
+  void setStream (uint32_t);
+
+  uint64_t getBeginTimeStamp() const;
+  void setBeginTimeStamp (uint64_t);
+
+  uint64_t getEndTimeStamp() const;
+  void setEndTimeStamp (uint64_t);
+
+  uint32_t getNumberOfSamples() const;
+  void resize (uint32_t num_samples);
+
+  uint32_t getDwellTime_ns() const;
+  void setDwellTime_ns (uint32_t);
+
+  int32_t getUserInt(uint32_t idx) const;
+  void setUserInt (uint32_t idx, int32_t val);
+
+  float getUserFloat (uint32_t idx) const;
+  void setUserFloat (uint32_t idx, float val);
+
+  WaveformHeader &getHead();
+  const WaveformHeader &getHead() const;
+  void setHead (const WaveformHeader &other);
+
+  std::vector<double> &getData();
+  const std::vector<double> &getData() const;
+  void setData (const std::vector<double> &data);
+
+  double &at (uint32_t sample);
+
+// Functions inherited from Entity
+  virtual uint32_t     getSignature () const;
+  virtual uint32_t     getVersion () const;
+  virtual uint32_t     getStream () const;
+  virtual EntityType   getEntityType () const;
+  virtual StorageType  getStorageType () const;
+
+  virtual std::vector<unsigned char> serialize();
+  virtual void deserialize(const std::vector<unsigned char>& buffer);
+
+  protected:
+
+  WaveformHeader head_;
+  std::vector<double> data_;
+};
+
+/*******************************************************************************
+ N-Dimensional array type
+*******************************************************************************/
+
 template <typename T>
 class EXPORTISMRMRD NDArray {
 public:
@@ -607,6 +700,7 @@ public:
 
     // Accessors and mutators
     uint32_t getSignature() const;
+    uint32_t getVersion() const;
     StorageType getStorageType() const;
 
     uint32_t getNDim() const;
@@ -619,7 +713,13 @@ public:
     const std::vector<T> &getData() const;
 
     // Returns a reference to the image data
-    T &at(uint32_t x, uint32_t y = 0, uint32_t z = 0, uint32_t w = 0, uint32_t n = 0, uint32_t m = 0, uint32_t l = 0);
+    T &at (uint32_t x,
+           uint32_t y = 0,
+           uint32_t z = 0,
+           uint32_t w = 0,
+           uint32_t n = 0,
+           uint32_t m = 0,
+           uint32_t l = 0);
 
 protected:
     void makeConsistent();

--- a/include/ismrmrd/xml.h
+++ b/include/ismrmrd/xml.h
@@ -8,7 +8,6 @@
 #define ISMRMRDXML_H
 
 #include "ismrmrd/export.h"
-#include "ismrmrd/ismrmrd.h"
 
 #include <cstddef>
 #include <new> //For std::badalloc
@@ -69,7 +68,7 @@ namespace ISMRMRD
 
     T& get() {
       if (!present_) {
-	throw std::runtime_error("Access optional value, which has not been set");
+  throw std::runtime_error("Access optional value, which has not been set");
       }
       return value_;
     }
@@ -320,19 +319,7 @@ namespace ISMRMRD
   };
 
   struct IsmrmrdHeader
-  : public Entity
   {
-    IsmrmrdHeader();
-    //void setStream (uint32_t stream_number);
-    virtual uint32_t  getSignature () const;
-    virtual uint32_t  getVersion () const;
-    virtual uint32_t  getStream ()  const;
-    virtual EntityType  getEntityType ()  const;
-    virtual StorageType getStorageType () const;
-    virtual std::vector<unsigned char> serialize();
-    virtual void deserialize(const std::vector<unsigned char>& buffer);
-
-    EntityHeader ent_head;
     Optional<long> version;
     Optional<SubjectInformation> subjectInformation;
     Optional<StudyInformation> studyInformation;

--- a/include/ismrmrd/xml.h
+++ b/include/ismrmrd/xml.h
@@ -8,6 +8,7 @@
 #define ISMRMRDXML_H
 
 #include "ismrmrd/export.h"
+#include "ismrmrd/ismrmrd.h"
 
 #include <cstddef>
 #include <new> //For std::badalloc
@@ -319,7 +320,19 @@ namespace ISMRMRD
   };
 
   struct IsmrmrdHeader
+  : public Entity
   {
+    IsmrmrdHeader();
+    //void setStream (uint32_t stream_number);
+    virtual uint32_t  getSignature () const;
+    virtual uint32_t  getVersion () const;
+    virtual uint32_t  getStream ()  const;
+    virtual EntityType  getEntityType ()  const;
+    virtual StorageType getStorageType () const;
+    virtual std::vector<unsigned char> serialize();
+    virtual void deserialize(const std::vector<unsigned char>& buffer);
+
+    EntityHeader ent_head;
     Optional<long> version;
     Optional<SubjectInformation> subjectInformation;
     Optional<StudyInformation> studyInformation;

--- a/libsrc/dataset.cpp
+++ b/libsrc/dataset.cpp
@@ -8,426 +8,584 @@
 
 namespace ISMRMRD {
 
-
-Dataset::Dataset(const std::string& filename, const std::string& groupname, bool create_file_if_needed, bool read_only)
-  : filename_(filename),
-    groupname_(groupname),
-    read_only_(read_only),
-    file_open_(false),
-    dataset_open_(false)
+/******************************************************************************/
+Dataset::Dataset
+(
+  const std::string& filename,
+  const std::string& groupname,
+  bool  create_file_if_needed,
+  bool  read_only
+)
+: filename_     (filename),
+  groupname_    (groupname),
+  read_only_    (read_only),
+  file_open_    (false),
+  dataset_open_ (false)
 {
-    std::ifstream ifile(filename_.c_str());
-    bool file_exists = ifile.is_open();
+  std::ifstream ifile (filename_.c_str());
+  bool file_exists = ifile.is_open();
 
-    int open_flag = read_only ? H5F_ACC_RDONLY : H5F_ACC_RDWR;
+  int open_flag = read_only ? H5F_ACC_RDONLY : H5F_ACC_RDWR;
 
-    if (file_exists) {
-        if (!H5File::isHdf5(filename_.c_str())) {
-            throw std::runtime_error("Not an HDF file");
-        }
-        file_ = H5File(filename_, open_flag);
-    } else if (create_file_if_needed) {
-        file_ = H5File(filename_, H5F_ACC_TRUNC);
-        // We will close and then immediately open the file again.
-        // We need to make sure the file is saved as an HDF5 file in case other processes and functions
-        // need to access it immediately. The line above does not cause the file to be marked as and HDF5 file.
-        // H5File::isHdf5(filename_.c_str()) will return false at this point.
-        file_.close();
-        file_ = H5File(filename_, open_flag);
-        file_open_ = true;
-    } else {
-        throw std::runtime_error("file not found");
+  if (file_exists)
+  {
+    if (!H5File::isHdf5 (filename_.c_str()))
+    {
+      throw std::runtime_error ("Not an HDF file");
     }
+    file_ = H5File (filename_, open_flag);
+  }
+  else if (create_file_if_needed)
+  {
+    file_ = H5File (filename_, H5F_ACC_TRUNC);
 
-    xml_header_path_ = groupname_ + "/xml";
-    data_path_ = groupname_ + "/data";
-    index_path_ = data_path_ + "/index";
+    // We will close and then immediately open the file again.
+    // We need to make sure the file is saved as an HDF5 file in case other
+    // processes and functions need to access it immediately. The line above
+    // does not cause the file to be marked as and HDF5 file.
+    // H5File::isHdf5 (filename_.c_str()) will return false at this point.
+    file_.close();
+    file_ = H5File (filename_, open_flag);
+    file_open_ = true;
+  }
+  else
+  {
+    throw std::runtime_error ("file not found");
+  }
 
-    // TODO: maybe the following steps should only happen for new files??
+  xml_header_path_ = groupname_ + "/xml";
+  data_path_ = groupname_ + "/data";
+  index_path_ = data_path_ + "/index";
 
-    // create groups for /dataset and /dataset/data
-    if (!linkExists(data_path_)) {
-        createGroup(data_path_);
-    }
+  // TODO: maybe the following steps should only happen for new files??
+
+  // create groups for /dataset and /dataset/data
+  if (!linkExists (data_path_))
+  {
+    createGroup (data_path_);
+  }
 }
 
-// Destructor
+/******************************************************************************/
 Dataset::~Dataset()
 {
-    file_.close();
+  file_.close();
 }
 
-bool Dataset::linkExists(const std::string& path)
+/******************************************************************************/
+bool Dataset::linkExists (const std::string& path)
 {
-    std::vector<std::string> elements;
-    std::string delimiter("/");
-    boost::split(elements, path, boost::is_any_of("/"));
-    std::string current_path;
-    for (std::vector<std::string>::const_iterator it = elements.begin(); it != elements.end(); ++it) {
-        if (it->size() > 0) {
-            current_path += "/" + *it;
-            if (!H5Lexists(file_.getId(), current_path.c_str(), H5P_DEFAULT)) {
-                return false;
-            }
-        }
+  std::vector<std::string> elements;
+  std::string delimiter ("/");
+  boost::split (elements, path, boost::is_any_of ("/"));
+  std::string current_path;
+
+  for (std::vector<std::string>::const_iterator it = elements.begin();
+       it != elements.end(); ++it)
+  {
+    if (it->size() > 0)
+    {
+      current_path += "/" + *it;
+
+      if (!H5Lexists (file_.getId(), current_path.c_str(), H5P_DEFAULT))
+      {
+        return false;
+      }
     }
-    return true;
+  }
+  return true;
 }
 
-void Dataset::createGroup(const std::string& path)
+/******************************************************************************/
+void Dataset::createGroup (const std::string& path)
 {
-    std::vector<std::string> elements;
-    boost::split(elements, path, boost::is_any_of("/"));
-    std::string current_path;
-    for (std::vector<std::string>::const_iterator it = elements.begin(); it != elements.end(); ++it) {
-        if (it->size() > 0) {
-            current_path += "/" + *it;
-            if (!H5Lexists(file_.getId(), current_path.c_str(), H5P_DEFAULT)) {
-                file_.createGroup(current_path.c_str());
-            }
-        }
+  std::vector<std::string> elements;
+  boost::split (elements, path, boost::is_any_of ("/"));
+  std::string current_path;
+
+  for (std::vector<std::string>::const_iterator it = elements.begin();
+       it != elements.end(); ++it)
+  {
+    if (it->size() > 0)
+    {
+      current_path += "/" + *it;
+      if (!H5Lexists (file_.getId(), current_path.c_str(), H5P_DEFAULT))
+      {
+        file_.createGroup (current_path.c_str());
+      }
     }
+  }
 }
 
-std::string Dataset::constructDataPath(unsigned int stream)
+/******************************************************************************/
+std::string Dataset::constructDataPath (unsigned int stream)
 {
-    // construct group path for this acquisition
-    std::stringstream sstr;
-    sstr << data_path_ << "/" << stream;
-    return sstr.str();
+  // construct group path for this acquisition
+  std::stringstream sstr;
+  sstr << data_path_ << "/" << stream;
+  return sstr.str();
 }
 
+/******************************************************************************/
 // XML Header
-void Dataset::writeHeader(const std::string& xml)
+void Dataset::writeHeader (const std::string& xml)
 {
-    std::vector<hsize_t> dims(1, 1);
-    std::vector<hsize_t> max_dims(1, 1);
+  std::vector<hsize_t> dims (1, 1);
+  std::vector<hsize_t> max_dims (1, 1);
 
-    DataSet xml_dataset;
-    DataType datatype = StrType(0, H5T_VARIABLE);
+  DataSet xml_dataset;
+  DataType datatype = StrType (0, H5T_VARIABLE);
 
-    if (!linkExists(xml_header_path_)) {
-        DataSpace mspace1(dims.size(), &dims[0], &max_dims[0]);
-        xml_dataset = DataSet(file_.createDataSet(xml_header_path_.c_str(), datatype, mspace1));
-    } else {
-        xml_dataset = DataSet(file_.openDataSet(xml_header_path_.c_str()));
-        DataType mtype = xml_dataset.getDataType();
-        // no `!=` operator for DataType so we use (!(expr)) here
-        if (!(mtype == datatype)) {
-            throw std::runtime_error("conflicting HDF5 types for XML header");
-        }
+  if (!linkExists (xml_header_path_))
+  {
+    DataSpace mspace1 (dims.size(), &dims[0], &max_dims[0]);
+    xml_dataset = DataSet (file_.createDataSet (xml_header_path_.c_str(),
+                                                datatype,
+                                                mspace1));
+  } else
+  {
+    xml_dataset = DataSet (file_.openDataSet (xml_header_path_.c_str()));
+    DataType mtype = xml_dataset.getDataType();
+    // no `!=` operator for DataType so we use (!(expr)) here
+    if (!(mtype == datatype))
+    {
+      throw std::runtime_error ("conflicting HDF5 types for XML header");
     }
+  }
 
     DataSpace mspace1 = xml_dataset.getSpace();
-    xml_dataset.write(xml, datatype, mspace1);
+    xml_dataset.write (xml, datatype, mspace1);
 }
 
+/******************************************************************************/
 std::string Dataset::readHeader()
 {
-    if (!linkExists(xml_header_path_)) {
-        throw std::runtime_error("XML header not found in file");
-    }
+  if (!linkExists (xml_header_path_))
+  {
+    throw std::runtime_error ("XML header not found in file");
+  }
 
-    DataSet xml_dataset = file_.openDataSet(xml_header_path_.c_str());
-    DataType datatype = StrType(0, H5T_VARIABLE);
+  DataSet xml_dataset = file_.openDataSet (xml_header_path_.c_str());
+  DataType datatype = StrType (0, H5T_VARIABLE);
 
-    DataType dt = xml_dataset.getDataType();
+  DataType dt = xml_dataset.getDataType();
 
-    std::string xml;
-    xml_dataset.read(xml, dt);
+  std::string xml;
+  xml_dataset.read (xml, dt);
 
-    return xml;
+  return xml;
 }
 
-template <typename T> void Dataset::appendAcquisition(const Acquisition<T>& acq, int stream)
-{
-    if (stream < 0) {
-        stream = acq.getStream();
-    }
-
-    std::string path = constructDataPath(stream);
-
-    std::vector<hsize_t> dims(2, 1);
-    DataType dtype = get_hdf5_data_type<AcquisitionHeader_with_data<T> >();
-
-    AcquisitionHeader_with_data<T> obj;
-    obj.head = acq.getHead();
-    obj.traj.len = acq.getTrajectoryDimensions() * acq.getNumberOfSamples();
-    obj.traj.p = const_cast<float*>(&acq.getTraj()[0]);
-    obj.data.len = acq.getActiveChannels() * acq.getNumberOfSamples() * 2;
-
-    std::vector<T> fdata;
-    std::vector<std::complex<T> > data = acq.getData();
-    for (typename std::vector<std::complex<T> >::const_iterator it = data.begin(); it != data.end(); ++it) {
-        fdata.push_back(it->real());
-        fdata.push_back(it->imag());
-    }
-    obj.data.p = const_cast<T*>(&fdata[0]);
-
-    // add the acquisition to its correct stream dataset
-    // note: subtract 1 to account for zero-indexing
-    unsigned int acquisition_number = appendToDataSet(path, dtype, dims, &obj) - 1;
-
-    // now add an entry to the index for this acquisition
-    dtype = get_hdf5_data_type<IndexEntry>();
-    dims = std::vector<hsize_t>(2, 1);
-    IndexEntry entry;
-    entry.stream = stream;
-    entry.index = acquisition_number;
-    appendToDataSet(index_path_, dtype, dims, &entry);
-}
-
-//Template instanciations
-template Acquisition<int16_t> Dataset::readAcquisition<int16_t>(unsigned long, int);
-template Acquisition<int32_t> Dataset::readAcquisition<int32_t>(unsigned long, int);
-template Acquisition<float> Dataset::readAcquisition<float>(unsigned long, int);
-    
-
-size_t Dataset::appendToDataSet(const std::string& path, const DataType& dtype,
-        const std::vector<hsize_t>& dims, void* data)
-{
-    bool first_entry = false;
-
-    // check if the dataset is already open
-    if (datasets_.count(path) == 0) {
-        // check if the dataset even exists
-        if (linkExists(path)) {
-            datasets_[path] = file_.openDataSet(path.c_str());
-        } else {
-            first_entry = true;
-
-            std::vector<hsize_t> max_dims = dims;
-            max_dims[0] = H5S_UNLIMITED;
-
-            DataSpace space(dims.size(), &dims[0], &max_dims[0]);
-
-            DSetCreatPropList cparms;
-            cparms.setChunk(dims.size(), &dims[0]);
-
-            datasets_[path] = file_.createDataSet(path.c_str(), dtype, space, cparms);
-        }
-    }
-
-    DataSet dset = datasets_[path];
-
-    unsigned int rank = dims.size();
-    // check rank of existing dataset
-    DataSpace mspace = dset.getSpace();
-    unsigned int cur_rank = mspace.getSimpleExtentNdims();
-    if (cur_rank != rank) {
-        throw std::runtime_error("incorrect rank in HDF5 dataset");
-    }
-
-    size_t length = 1;
-    // extend current dataset and determine offset for new entry
-    std::vector<hsize_t> offset(rank, 0);
-    if (!first_entry) {
-        std::vector<hsize_t> ddims(rank, 1);
-        mspace.getSimpleExtentDims(&ddims[0], NULL);
-        offset[0] = ddims[0];
-        length = ++ddims[0];
-        dset.extend(&ddims[0]);
-    }
-
-    // select space in file for new entry
-    DataSpace fspace = dset.getSpace();
-    fspace.selectHyperslab(H5S_SELECT_SET, &dims[0], &offset[0]);
-
-    // append entry to index dataset
-    mspace = DataSpace(rank, &dims[0]);
-    dset.write(data, dtype, mspace, fspace);
-
-    return length;
-}
-
-void Dataset::readFromDataSet(const std::string& path, const DataType& dtype,
-        const std::vector<hsize_t>& entry_dims, size_t index, void* data)
-{
-    if (!linkExists(path)) {
-        throw std::runtime_error("Data path does not exist in dataset");
-    }
-
-    if (datasets_.count(path) == 0) {
-        datasets_[path] = file_.openDataSet(path);
-    }
-
-    DataSet dset = datasets_[path];
-
-    DataType actual_dtype = dset.getDataType();
-    // no `!=` operator for DataType so we use (!(a == b)) here
-    if (!(actual_dtype == dtype)) {
-        throw std::runtime_error("Attempting to open HDF5 Dataset with incorrect datatype");
-    }
-
-    DataSpace dspace = dset.getSpace();
-    unsigned int rank = dspace.getSimpleExtentNdims();
-    std::vector<hsize_t> dims(rank);
-    dspace.getSimpleExtentDims(&dims[0]);
-
-    if (index >= dims[0]) {
-        throw std::runtime_error("Attempting to access non-existent hyperslice in HDF5 dataset");
-    }
-
-    std::vector<hsize_t> offset(rank);
-    offset[0] = index;
-
-    dspace.selectHyperslab(H5S_SELECT_SET, &entry_dims[0], &offset[0]);
-    DataSpace mspace(rank, &entry_dims[0]);
-
-    dset.read(data, dtype, mspace, dspace, H5P_DEFAULT);
-}
-
-template <typename T> Acquisition<T> Dataset::readAcquisition(unsigned long index, int stream)
-{
-    if (stream < 0) {
-        IndexEntry entry;
-        std::vector<hsize_t> entry_dims(2, 1);
-        DataType dtype = get_hdf5_data_type<IndexEntry>();
-
-        readFromDataSet(index_path_, dtype, entry_dims, index, &entry);
-
-        stream = entry.stream;
-        index = entry.index;
-    }
-
-    std::string path = constructDataPath(stream);
-
-    AcquisitionHeader_with_data<T> obj;
-    DataType dtype = get_hdf5_data_type<AcquisitionHeader_with_data<T> >();
-    std::vector<hsize_t> entry_dims(2, 1);
-    readFromDataSet(path, dtype, entry_dims, index, &obj);
-
-    Acquisition<T> acq;
-    acq.setHead(obj.head);
-
-    if (obj.data.len != acq.getData().size() * 2) {
-        throw std::runtime_error("Header does not match data length in file");
-    }
-    if (obj.traj.len != acq.getTraj().size()) {
-        throw std::runtime_error("Header does not match trajectory length in file");
-    }
-
-    // TODO: fix this ASAP:
-    memcpy(const_cast<std::complex<T>*>(&acq.getData()[0]), obj.data.p, sizeof(T) * obj.data.len);
-    memcpy(const_cast<float*>(&acq.getTraj()[0]), obj.traj.p, sizeof(float) * obj.traj.len);
-
-    free(obj.data.p);
-    free(obj.traj.p);
-
-    return acq;
-}
-
-template void Dataset::appendAcquisition(const Acquisition<int16_t>&, int);
-template void Dataset::appendAcquisition(const Acquisition<int32_t>&, int);
-template void Dataset::appendAcquisition(const Acquisition<float>&, int);
-    
-unsigned long Dataset::getNumberOfAcquisitions(int stream)
-{
-    std::string path;
-    if (stream < 0) {
-        path = index_path_;
-    } else {
-        path = constructDataPath(stream);
-    }
-
-    if (!linkExists(path)) {
-        throw std::runtime_error("Data path does not exist in dataset");
-    }
-
-    // check if dataset is open
-    if (datasets_.count(path) == 0) {
-        datasets_[path] = file_.openDataSet(path);
-    }
-
-    DataSet dataset = datasets_[path];
-
-    DataSpace space = dataset.getSpace();
-    int rank = space.getSimpleExtentNdims();
-    std::vector<hsize_t> dims(rank, 0);
-    space.getSimpleExtentDims(&dims[0]);
-    unsigned long nacq = dims[0];
-
-    return nacq;
-}
-
-template <typename T> void Dataset::appendImage(const std::string& var, const Image<T>& im)
-{
-    // TODO: implement
-}
-
-template EXPORTISMRMRD void Dataset::appendImage(const std::string& var, const Image<uint16_t>& im);
-template EXPORTISMRMRD void Dataset::appendImage(const std::string& var, const Image<int16_t>& im);
-template EXPORTISMRMRD void Dataset::appendImage(const std::string& var, const Image<uint32_t>& im);
-template EXPORTISMRMRD void Dataset::appendImage(const std::string& var, const Image<int32_t>& im);
-template EXPORTISMRMRD void Dataset::appendImage(const std::string& var, const Image<float>& im);
-template EXPORTISMRMRD void Dataset::appendImage(const std::string& var, const Image<double>& im);
-template EXPORTISMRMRD void Dataset::appendImage(const std::string& var, const Image<std::complex<float> >& im);
-template EXPORTISMRMRD void Dataset::appendImage(const std::string& var, const Image<std::complex<double> >& im);
-
-
+/******************************************************************************/
 template <typename T>
-Image<T> Dataset::readImage (const std::string& var, unsigned long index)
+void Dataset::appendAcquisition
+(
+  const Acquisition<T>& acq,
+  int                   stream
+)
+{
+  if (stream < 0)
+  {
+    throw std::runtime_error ("Invalid MRAcquisition stream number");
+  }
+
+  std::string path = constructDataPath (stream);
+
+  std::vector<hsize_t> dims (2, 1);
+  DataType dtype = get_hdf5_data_type<AcquisitionHeader_with_data<T> >();
+
+  AcquisitionHeader_with_data<T> obj;
+  obj.head = acq.getHead();
+  obj.traj.len = acq.getTrajectoryDimensions() * acq.getNumberOfSamples();
+  obj.traj.p = const_cast<float*> (&acq.getTraj()[0]);
+  obj.data.len = acq.getActiveChannels() * acq.getNumberOfSamples() * 2;
+
+  std::vector<T> fdata;
+  std::vector<std::complex<T> > data = acq.getData();
+  for (typename std::vector<std::complex<T> >::const_iterator it = data.begin();
+       it != data.end(); ++it)
+  {
+    fdata.push_back (it->real());
+    fdata.push_back (it->imag());
+  }
+  obj.data.p = const_cast<T*> (&fdata[0]);
+
+  // add the acquisition to its correct stream dataset
+  // note: subtract 1 to account for zero-indexing
+  unsigned int acquisition_number =
+    appendToDataSet (path, dtype, dims, &obj) - 1;
+
+  // now add an entry to the index for this acquisition
+  dtype = get_hdf5_data_type<IndexEntry>();
+  dims = std::vector<hsize_t> (2, 1);
+  IndexEntry entry;
+  entry.stream = stream;
+  entry.index = acquisition_number;
+  appendToDataSet (index_path_, dtype, dims, &entry);
+}
+
+/******************************************************************************/
+//Template instanciations
+template Acquisition<int16_t>
+  Dataset::readAcquisition<int16_t> (unsigned long, int);
+template Acquisition<int32_t>
+  Dataset::readAcquisition<int32_t> (unsigned long, int);
+template Acquisition<float>
+  Dataset::readAcquisition<float> (unsigned long, int);
+
+/******************************************************************************/
+size_t Dataset::appendToDataSet
+(
+  const std::string&          path,
+  const DataType&             dtype,
+  const std::vector<hsize_t>& dims,
+  void*                       data
+)
+{
+  bool first_entry = false;
+
+  // check if the dataset is already open
+  if (datasets_.count (path) == 0)
+  {
+    // check if the dataset even exists
+    if (linkExists (path))
+    {
+      datasets_[path] = file_.openDataSet (path.c_str());
+    }
+    else
+    {
+      first_entry = true;
+
+      std::vector<hsize_t> max_dims = dims;
+      max_dims[0] = H5S_UNLIMITED;
+
+      DataSpace space (dims.size(), &dims[0], &max_dims[0]);
+
+      DSetCreatPropList cparms;
+      cparms.setChunk (dims.size(), &dims[0]);
+
+      datasets_[path] = file_.createDataSet (path.c_str(), dtype, space, cparms);
+    }
+  }
+
+  DataSet dset = datasets_[path];
+
+  unsigned int rank = dims.size();
+  // check rank of existing dataset
+  DataSpace mspace = dset.getSpace();
+  unsigned int cur_rank = mspace.getSimpleExtentNdims();
+  if (cur_rank != rank)
+  {
+    throw std::runtime_error ("incorrect rank in HDF5 dataset");
+  }
+
+  size_t length = 1;
+  // extend current dataset and determine offset for new entry
+  std::vector<hsize_t> offset (rank, 0);
+  if (!first_entry)
+  {
+    std::vector<hsize_t> ddims (rank, 1);
+    mspace.getSimpleExtentDims (&ddims[0], NULL);
+    offset[0] = ddims[0];
+    length = ++ddims[0];
+    dset.extend (&ddims[0]);
+  }
+
+  // select space in file for new entry
+  DataSpace fspace = dset.getSpace();
+  fspace.selectHyperslab (H5S_SELECT_SET, &dims[0], &offset[0]);
+
+  // append entry to index dataset
+  mspace = DataSpace (rank, &dims[0]);
+  dset.write (data, dtype, mspace, fspace);
+
+  return length;
+}
+
+/******************************************************************************/
+void Dataset::readFromDataSet
+(
+  const std::string&          path,
+  const DataType&             dtype,
+  const std::vector<hsize_t>& entry_dims,
+  size_t                      index,
+  void*                       data
+)
+{
+  if (!linkExists (path))
+  {
+    throw std::runtime_error ("Data path does not exist in dataset");
+  }
+
+  if (datasets_.count (path) == 0)
+  {
+    datasets_[path] = file_.openDataSet (path);
+  }
+
+  DataSet dset = datasets_[path];
+
+  DataType actual_dtype = dset.getDataType();
+  // no `!=` operator for DataType so we use (!(a == b)) here
+  if (!(actual_dtype == dtype))
+  {
+    throw std::runtime_error
+      ("Attempting to open HDF5 Dataset with incorrect datatype");
+  }
+
+  DataSpace dspace = dset.getSpace();
+  unsigned int rank = dspace.getSimpleExtentNdims();
+  std::vector<hsize_t> dims (rank);
+  dspace.getSimpleExtentDims (&dims[0]);
+
+  if (index >= dims[0])
+  {
+    throw std::runtime_error
+      ("Attempting to access non-existent hyperslice in HDF5 dataset");
+  }
+
+  std::vector<hsize_t> offset (rank);
+  offset[0] = index;
+
+  dspace.selectHyperslab (H5S_SELECT_SET, &entry_dims[0], &offset[0]);
+  DataSpace mspace (rank, &entry_dims[0]);
+
+  dset.read (data, dtype, mspace, dspace, H5P_DEFAULT);
+}
+
+/******************************************************************************/
+template <typename T>
+Acquisition<T> Dataset::readAcquisition
+(
+  unsigned long index,
+  int           stream
+)
+{
+  if (stream < 0)
+  {
+    IndexEntry entry;
+    std::vector<hsize_t> entry_dims (2, 1);
+    DataType dtype = get_hdf5_data_type<IndexEntry>();
+
+    readFromDataSet (index_path_, dtype, entry_dims, index, &entry);
+
+    stream = entry.stream;
+    index = entry.index;
+  }
+
+  std::string path = constructDataPath (stream);
+
+  AcquisitionHeader_with_data<T> obj;
+  DataType dtype = get_hdf5_data_type<AcquisitionHeader_with_data<T> >();
+  std::vector<hsize_t> entry_dims (2, 1);
+  readFromDataSet (path, dtype, entry_dims, index, &obj);
+
+  Acquisition<T> acq;
+  acq.setHead (obj.head);
+
+  if (obj.data.len != acq.getData().size() * 2)
+  {
+    throw std::runtime_error ("Header does not match data length in file");
+  }
+  if (obj.traj.len != acq.getTraj().size())
+  {
+    throw std::runtime_error ("Header does not match trajectory length in file");
+  }
+
+  // TODO: fix this ASAP:
+  memcpy (const_cast<std::complex<T>*> (&acq.getData()[0]),
+          obj.data.p,
+          sizeof(T) * obj.data.len);
+
+  memcpy (const_cast<float*> (&acq.getTraj()[0]),
+          obj.traj.p,
+          sizeof(float) * obj.traj.len);
+
+  free (obj.data.p);
+  free (obj.traj.p);
+
+  return acq;
+}
+
+/******************************************************************************/
+template void Dataset::appendAcquisition (const Acquisition<int16_t>&, int);
+template void Dataset::appendAcquisition (const Acquisition<int32_t>&, int);
+template void Dataset::appendAcquisition (const Acquisition<float>&, int);
+    
+/******************************************************************************/
+unsigned long Dataset::getNumberOfAcquisitions (int stream)
+{
+  std::string path;
+  if (stream < 0)
+  {
+    path = index_path_;
+  }
+  else
+  {
+    path = constructDataPath (stream);
+  }
+
+  if (!linkExists (path))
+  {
+    throw std::runtime_error ("Data path does not exist in dataset");
+  }
+
+  // check if dataset is open
+  if (datasets_.count (path) == 0)
+  {
+    datasets_[path] = file_.openDataSet (path);
+  }
+
+  DataSet dataset = datasets_[path];
+
+  DataSpace space = dataset.getSpace();
+  int rank = space.getSimpleExtentNdims();
+  std::vector<hsize_t> dims (rank, 0);
+  space.getSimpleExtentDims (&dims[0]);
+  unsigned long nacq = dims[0];
+
+  return nacq;
+}
+
+/******************************************************************************/
+template <typename T>
+void Dataset::appendImage
+(
+  const std::string& var,
+  const Image<T>& im
+)
+{
+  // TODO: implement
+}
+
+/******************************************************************************/
+template EXPORTISMRMRD void Dataset::appendImage
+  (const std::string& var, const Image<uint16_t>& im);
+template EXPORTISMRMRD void Dataset::appendImage
+  (const std::string& var, const Image<int16_t>& im);
+template EXPORTISMRMRD void Dataset::appendImage
+  (const std::string& var, const Image<uint32_t>& im);
+template EXPORTISMRMRD void Dataset::appendImage
+  (const std::string& var, const Image<int32_t>& im);
+template EXPORTISMRMRD void Dataset::appendImage
+  (const std::string& var, const Image<float>& im);
+template EXPORTISMRMRD void Dataset::appendImage
+  (const std::string& var, const Image<double>& im);
+template EXPORTISMRMRD void Dataset::appendImage
+  (const std::string& var, const Image<std::complex<float> >& im);
+template EXPORTISMRMRD void Dataset::appendImage
+  (const std::string& var, const Image<std::complex<double> >& im);
+
+/******************************************************************************/
+template <typename T>
+Image<T> Dataset::readImage
+(
+  const std::string& var,
+  unsigned long index
+)
 {
   // TODO: implement
   return Image<T>();
 }
 
-template EXPORTISMRMRD Image<uint16_t> Dataset::readImage(const std::string& var, unsigned long index);
-template EXPORTISMRMRD Image<int16_t> Dataset::readImage(const std::string& var, unsigned long index);
-template EXPORTISMRMRD Image<uint32_t> Dataset::readImage(const std::string& var, unsigned long index);
-template EXPORTISMRMRD Image<int32_t> Dataset::readImage(const std::string& var, unsigned long index);
-template EXPORTISMRMRD Image<float> Dataset::readImage(const std::string& var, unsigned long index);
-template EXPORTISMRMRD Image<double> Dataset::readImage(const std::string& var, unsigned long index);
-template EXPORTISMRMRD Image<std::complex<float> > Dataset::readImage(const std::string& var, unsigned long index);
-template EXPORTISMRMRD Image<std::complex<double> > Dataset::readImage(const std::string& var, unsigned long index);
+/******************************************************************************/
+template EXPORTISMRMRD Image<uint16_t> Dataset::readImage
+  (const std::string& var, unsigned long index);
+template EXPORTISMRMRD Image<int16_t> Dataset::readImage
+  (const std::string& var, unsigned long index);
+template EXPORTISMRMRD Image<uint32_t> Dataset::readImage
+  (const std::string& var, unsigned long index);
+template EXPORTISMRMRD Image<int32_t> Dataset::readImage
+  (const std::string& var, unsigned long index);
+template EXPORTISMRMRD Image<float> Dataset::readImage
+  (const std::string& var, unsigned long index);
+template EXPORTISMRMRD Image<double> Dataset::readImage
+  (const std::string& var, unsigned long index);
+template EXPORTISMRMRD Image<std::complex<float> > Dataset::readImage
+  (const std::string& var, unsigned long index);
+template EXPORTISMRMRD Image<std::complex<double> > Dataset::readImage
+  (const std::string& var, unsigned long index);
 
-unsigned long Dataset::getNumberOfImages(const std::string& var)
+/******************************************************************************/
+unsigned long Dataset::getNumberOfImages
+(
+  const std::string& var
+)
 {
-    unsigned long nimg = 0;
+  unsigned long nimg = 0;
 
-    // TODO: implement
+  // TODO: implement
 
-    return nimg;
+  return nimg;
 }
 
-template <typename T> void Dataset::appendNDArray(const std::string& var, const NDArray<T>& arr)
-{
-    // TODO: implement
-}
-
-template EXPORTISMRMRD void Dataset::appendNDArray(const std::string& var, const NDArray<uint16_t>& arr);
-template EXPORTISMRMRD void Dataset::appendNDArray(const std::string& var, const NDArray<int16_t>& arr);
-template EXPORTISMRMRD void Dataset::appendNDArray(const std::string& var, const NDArray<uint32_t>& arr);
-template EXPORTISMRMRD void Dataset::appendNDArray(const std::string& var, const NDArray<int32_t>& arr);
-template EXPORTISMRMRD void Dataset::appendNDArray(const std::string& var, const NDArray<float>& arr);
-template EXPORTISMRMRD void Dataset::appendNDArray(const std::string& var, const NDArray<double>& arr);
-template EXPORTISMRMRD void Dataset::appendNDArray(const std::string& var, const NDArray<std::complex<float> >& arr);
-template EXPORTISMRMRD void Dataset::appendNDArray(const std::string& var, const NDArray<std::complex<double> >& arr);
-
+/******************************************************************************/
 template <typename T>
-NDArray<T> Dataset::readNDArray(const std::string& var, unsigned long index)
+void Dataset::appendNDArray
+(
+  const std::string& var,
+  const NDArray<T>&  arr
+)
 {
-    // TODO: implement
-    return NDArray<T>();
+  // TODO: implement
 }
 
-template EXPORTISMRMRD NDArray<uint16_t> Dataset::readNDArray(const std::string& var, unsigned long index);
-template EXPORTISMRMRD NDArray<int16_t> Dataset::readNDArray(const std::string& var, unsigned long index);
-template EXPORTISMRMRD NDArray<uint32_t> Dataset::readNDArray(const std::string& var, unsigned long index);
-template EXPORTISMRMRD NDArray<int32_t> Dataset::readNDArray(const std::string& var, unsigned long index);
-template EXPORTISMRMRD NDArray<float> Dataset::readNDArray(const std::string& var, unsigned long index);
-template EXPORTISMRMRD NDArray<double> Dataset::readNDArray(const std::string& var, unsigned long index);
-template EXPORTISMRMRD NDArray<std::complex<float> > Dataset::readNDArray(const std::string& var, unsigned long index);
-template EXPORTISMRMRD NDArray<std::complex<double> > Dataset::readNDArray(const std::string& var, unsigned long index);
+/******************************************************************************/
+template EXPORTISMRMRD void Dataset::appendNDArray
+  (const std::string& var, const NDArray<uint16_t>& arr);
+template EXPORTISMRMRD void Dataset::appendNDArray
+  (const std::string& var, const NDArray<int16_t>& arr);
+template EXPORTISMRMRD void Dataset::appendNDArray
+  (const std::string& var, const NDArray<uint32_t>& arr);
+template EXPORTISMRMRD void Dataset::appendNDArray
+  (const std::string& var, const NDArray<int32_t>& arr);
+template EXPORTISMRMRD void Dataset::appendNDArray
+  (const std::string& var, const NDArray<float>& arr);
+template EXPORTISMRMRD void Dataset::appendNDArray
+  (const std::string& var, const NDArray<double>& arr);
+template EXPORTISMRMRD void Dataset::appendNDArray
+  (const std::string& var, const NDArray<std::complex<float> >& arr);
+template EXPORTISMRMRD void Dataset::appendNDArray
+  (const std::string& var, const NDArray<std::complex<double> >& arr);
 
-unsigned long Dataset::getNumberOfNDArrays(const std::string& var)
+/******************************************************************************/
+template <typename T>
+NDArray<T> Dataset::readNDArray
+(
+  const std::string& var,
+  unsigned long index
+)
 {
-    unsigned long narr = 0;
-
-    // TODO: implement
-
-    return narr;
+  // TODO: implement
+  return NDArray<T>();
 }
 
+/******************************************************************************/
+template EXPORTISMRMRD NDArray<uint16_t>
+  Dataset::readNDArray (const std::string& var, unsigned long index);
+template EXPORTISMRMRD NDArray<int16_t>
+  Dataset::readNDArray (const std::string& var, unsigned long index);
+template EXPORTISMRMRD NDArray<uint32_t>
+  Dataset::readNDArray (const std::string& var, unsigned long index);
+template EXPORTISMRMRD NDArray<int32_t>
+  Dataset::readNDArray (const std::string& var, unsigned long index);
+template EXPORTISMRMRD NDArray<float>
+  Dataset::readNDArray (const std::string& var, unsigned long index);
+template EXPORTISMRMRD NDArray<double>
+  Dataset::readNDArray (const std::string& var, unsigned long index);
+template EXPORTISMRMRD NDArray<std::complex<float> >
+  Dataset::readNDArray (const std::string& var, unsigned long index);
+template EXPORTISMRMRD NDArray<std::complex<double> >
+  Dataset::readNDArray (const std::string& var, unsigned long index);
 
+/******************************************************************************/
+unsigned long Dataset::getNumberOfNDArrays (const std::string& var)
+{
+  unsigned long narr = 0;
+
+  // TODO: implement
+
+  return narr;
+}
+
+/******************************************************************************/
 } // namespace ISMRMRD

--- a/libsrc/ismrmrd.cpp
+++ b/libsrc/ismrmrd.cpp
@@ -651,6 +651,12 @@ uint32_t Acquisition<T>::getSignature () const
 }
 
 template <typename T>
+uint32_t Acquisition<T>::getVersion () const
+{
+  return head_.ent_head.signature & 0xFF;
+}
+
+template <typename T>
 EntityType Acquisition<T>::getEntityType () const
 {
   return static_cast<EntityType>(head_.ent_head.entity_type);
@@ -773,41 +779,50 @@ template <typename T>
   uint32_t channels
 )
 {
-    memset (&head_, 0, sizeof(head_));
-    head_.ent_head.signature = ISMRMRD_SIGNATURE;
-    head_.ent_head.entity_type = ISMRMRD_IMAGE;
-    head_.ent_head.storage_type = static_cast<uint32_t>(get_storage_type<T>());
-    this->resize (matrix_size_x, matrix_size_y, matrix_size_z, channels);
+  memset (&head_, 0, sizeof(head_));
+  head_.ent_head.signature    = ISMRMRD_SIGNATURE;
+  head_.ent_head.entity_type  = ISMRMRD_IMAGE;
+  head_.ent_head.storage_type = static_cast<uint32_t>(get_storage_type<T>());
+  this->resize (matrix_size_x, matrix_size_y, matrix_size_z, channels);
 }
 
 // Image dimensions
-template <typename T> void Image<T>::resize(uint32_t matrix_size_x,
-                                            uint32_t matrix_size_y,
-                                            uint32_t matrix_size_z,
-                                            uint32_t channels)
+template <typename T>
+void Image<T>::resize (uint32_t matrix_size_x,
+                       uint32_t matrix_size_y,
+                       uint32_t matrix_size_z,
+                       uint32_t channels)
 {
-    head_.matrix_size[0] = matrix_size_x;
-    head_.matrix_size[1] = matrix_size_y;
-    head_.matrix_size[2] = matrix_size_z;
-    head_.channels = channels;
-    this->makeConsistent();
+  head_.matrix_size[0] = matrix_size_x;
+  head_.matrix_size[1] = matrix_size_y;
+  head_.matrix_size[2] = matrix_size_z;
+  head_.channels = channels;
+  this->makeConsistent();
 }
 
-template <typename T> void Image<T>::makeConsistent() {
-    // TODO what if matrix_size[0] = 0?
+template <typename T>
+void Image<T>::makeConsistent()
+{
+  // TODO what if matrix_size[0] = 0?
 
-    if (head_.matrix_size[1] == 0) {
-        head_.matrix_size[1] = 1;
-    }
-    if (head_.matrix_size[2] == 0) {
-        head_.matrix_size[2] = 1;
-    }
-    if (head_.channels == 0) {
-        head_.channels = 1;
-    }
-    data_.resize(getNumberOfElements());
+  if (head_.matrix_size[1] == 0)
+  {
+    head_.matrix_size[1] = 1;
+  }
 
-    attribute_string_.resize(head_.attribute_string_len);
+  if (head_.matrix_size[2] == 0)
+  {
+    head_.matrix_size[2] = 1;
+  }
+
+  if (head_.channels == 0)
+  {
+    head_.channels = 1;
+  }
+
+  data_.resize (getNumberOfElements());
+
+  attribute_string_.resize (head_.attribute_string_len);
 }
 
 template <typename T>
@@ -1156,16 +1171,28 @@ template <typename T> void  Image<T>::setTimeStamp(uint64_t time_stamp)
     head_.time_stamp = time_stamp;
 }
 
-template <typename T> uint32_t Image<T>::getPhysiologyTimeStamp(unsigned int idx) const
+template <typename T>
+uint32_t Image<T>::getPhysiologyTimeStamp (unsigned int idx) const
 {
-    // TODO: bounds checking
-    return head_.physiology_time_stamp[idx];
+  if (idx >= ISMRMRD_PHYS_STAMPS)
+  {
+    throw std::runtime_error ("Image physiology timestamp index out of bounds");
+  }
+  return head_.physiology_time_stamp[idx];
 }
 
-template <typename T> void  Image<T>::setPhysiologyTimeStamp(unsigned int idx, uint32_t value)
+template <typename T>
+void  Image<T>::setPhysiologyTimeStamp
+(
+  unsigned int idx,
+  uint32_t     value
+)
 {
-    // TODO: bounds checking
-    head_.physiology_time_stamp[idx] = value;
+  if (idx >= ISMRMRD_PHYS_STAMPS)
+  {
+    throw std::runtime_error ("Image physiology timestamp index out of bounds");
+  }
+  head_.physiology_time_stamp[idx] = value;
 }
 
 template <typename T> uint32_t Image<T>::getImageType() const
@@ -1198,28 +1225,52 @@ template <typename T> void Image<T>::setImageSeriesIndex(uint32_t image_series_i
     head_.image_series_index = image_series_index;
 }
 
-template <typename T> int32_t Image<T>::getUserInt(unsigned int index) const
+template <typename T>
+int32_t Image<T>::getUserInt (unsigned int index) const
 {
-    // TODO: bounds checking
-    return head_.user_int[index];
+  if (index >= ISMRMRD_USER_INTS)
+  {
+    throw std::runtime_error ("Image user int index out of bounds");
+  }
+  return head_.user_int[index];
 }
 
-template <typename T> void Image<T>::setUserInt(unsigned int index, int32_t value)
+template <typename T>
+void Image<T>::setUserInt
+(
+  unsigned int index,
+  int32_t      value
+)
 {
-    // TODO: bounds checking
-    head_.user_int[index] = value;
+  if (index >= ISMRMRD_USER_INTS)
+  {
+    throw std::runtime_error ("Image user int index out of bounds");
+  }
+  head_.user_int[index] = value;
 }
 
-template <typename T> float Image<T>::getUserFloat(unsigned int index) const
+template <typename T>
+float Image<T>::getUserFloat (unsigned int index) const
 {
-    // TODO: bounds checking
-    return head_.user_float[index];
+  if (index >= ISMRMRD_USER_FLOATS)
+  {
+    throw std::runtime_error ("Image user float index out of bounds");
+  }
+  return head_.user_float[index];
 }
 
-template <typename T> void Image<T>::setUserFloat(unsigned int index, float value)
+template <typename T>
+void Image<T>::setUserFloat
+(
+  unsigned int index,
+  float        value
+)
 {
-    // TODO: bounds checking
-    head_.user_float[index] = value;
+  if (index >= ISMRMRD_USER_FLOATS)
+  {
+    throw std::runtime_error ("Image user float index out of bounds");
+  }
+  head_.user_float[index] = value;
 }
 
 // Flag methods
@@ -1313,15 +1364,24 @@ template <typename T> const std::vector<T>& Image<T>::getData() const {
      return data_;
 }
 
-template <typename T> size_t Image<T>::getNumberOfElements() const {
-    return head_.matrix_size[0] * head_.matrix_size[1] *
-            head_.matrix_size[2] * head_.channels;
+template <typename T>
+size_t Image<T>::getNumberOfElements() const
+{
+  return head_.matrix_size[0] * head_.matrix_size[1] *
+         head_.matrix_size[2] * head_.channels;
 }
 
 template <typename T>
 T& Image<T>::at (uint32_t ix, uint32_t iy, uint32_t iz, uint32_t channel)
 {
-  // TODO: bounds checking
+  if (ix >= head_.matrix_size[0] ||
+      iy >= head_.matrix_size[1] ||
+      iz >= head_.matrix_size[2] ||
+      channel >= head_.channels)
+  {
+    throw std::runtime_error ("Image data index out of bounds");
+  }
+
   size_t sx = getMatrixSizeX();
   size_t sy = getMatrixSizeY();
   size_t sz = getMatrixSizeZ();
@@ -1339,6 +1399,12 @@ template <typename T>
 uint32_t Image<T>::getSignature ()   const
 {
   return head_.ent_head.signature;
+}
+
+template <typename T>
+uint32_t Image<T>::getVersion ()   const
+{
+  return head_.ent_head.signature & 0xFF;
 }
 
 template <typename T>
@@ -1450,9 +1516,282 @@ void Image<T>::deserialize (const std::vector<unsigned char>& buffer)
              (unsigned char*)(&this->data_[0]));
 }
     
-//
-// Array class Implementation
-//
+/********************************* Waveform ***********************************/
+/******************************************************************************/
+bool operator== (const WaveformHeader& h1, const WaveformHeader& h2)
+{
+  return memcmp (&h1, &h2, sizeof(h1)) == 0;
+}
+
+/******************************************************************************/
+Waveform::Waveform (uint32_t num_samples)
+{
+  memset (&head_, 0, sizeof (head_));
+  head_.ent_head.signature    = ISMRMRD_SIGNATURE;
+  head_.ent_head.entity_type  = ISMRMRD_WAVEFORM;
+  head_.ent_head.storage_type = ISMRMRD_DOUBLE;
+  head_.number_of_samples     = num_samples;
+  data_.resize (num_samples);
+}
+
+/******************************************************************************/
+std::vector<double> &Waveform::getData()
+{
+  return data_;
+}
+
+/******************************************************************************/
+const std::vector<double> &Waveform::getData() const
+{
+  return data_;
+}
+
+/******************************************************************************/
+void Waveform::setData (const std::vector<double>& data)
+{
+  if (head_.number_of_samples != data.size())
+  {
+    throw std::runtime_error
+      ("Data size does not match size specified by header");
+  }
+
+  data_ = data;
+}
+
+/******************************************************************************/
+double &Waveform::at (uint32_t sample)
+{
+  if (sample >= head_.number_of_samples)
+  {
+    throw std::runtime_error ("waveform sample greater than number of samples");
+  }
+  return data_[sample];
+}
+
+/******************************************************************************/
+uint64_t Waveform::getBeginTimeStamp() const
+{
+  return head_.begin_time_stamp;
+}
+
+/******************************************************************************/
+void Waveform::setBeginTimeStamp (uint64_t ts)
+{
+  head_.begin_time_stamp = ts;
+}
+
+/******************************************************************************/
+uint64_t Waveform::getEndTimeStamp() const
+{
+  return head_.end_time_stamp;
+}
+
+/******************************************************************************/
+void Waveform::setEndTimeStamp (uint64_t ts)
+{
+  head_.end_time_stamp = ts;
+}
+
+/******************************************************************************/
+void Waveform::setStream (uint32_t stream_number)
+{
+  head_.ent_head.stream = stream_number;
+}
+
+/******************************************************************************/
+uint32_t Waveform::getNumberOfSamples() const
+{
+  return head_.number_of_samples;
+}
+
+/******************************************************************************/
+uint32_t Waveform::getDwellTime_ns() const
+{
+  return head_.dwell_time_ns;
+}
+
+/******************************************************************************/
+void Waveform::setDwellTime_ns (uint32_t dwell_time)
+{
+  head_.dwell_time_ns = dwell_time;
+}
+
+/******************************************************************************/
+int32_t Waveform::getUserInt (uint32_t idx) const
+{
+  if (idx >= ISMRMRD_USER_INTS)
+  {
+    throw std::runtime_error ("User int index out of bounds");
+  }
+  return head_.user_int[idx];
+}
+
+/******************************************************************************/
+void Waveform::setUserInt (uint32_t idx, int32_t val)
+{
+  if (idx >= ISMRMRD_USER_INTS)
+  {
+    throw std::runtime_error ("User int index out of bounds");
+  }
+  head_.user_int[idx] = val;
+}
+
+/******************************************************************************/
+float Waveform::getUserFloat (uint32_t idx) const
+{
+  if (idx >= ISMRMRD_USER_FLOATS)
+  {
+    throw std::runtime_error ("User float index out of bounds");
+  }
+  return head_.user_float[idx];
+}
+
+/******************************************************************************/
+void Waveform::setUserFloat (uint32_t idx, float val)
+{
+  if (idx >= ISMRMRD_USER_FLOATS)
+  {
+    throw std::runtime_error ("User float index out of bounds");
+  }
+  head_.user_float[idx] = val;
+}
+
+/******************************************************************************/
+void Waveform::resize (uint32_t num_samples)
+{
+  head_.number_of_samples = num_samples;
+  data_.resize (num_samples);
+}
+
+/******************************************************************************/
+WaveformHeader &Waveform::getHead()
+{
+  return head_;
+}
+
+/******************************************************************************/
+const WaveformHeader &Waveform::getHead () const
+{
+  return head_;
+}
+
+/******************************************************************************/
+void Waveform::setHead (const WaveformHeader &other)
+{
+  this->head_ = other;
+  data_.resize (head_.number_of_samples);
+}
+
+/******************************************************************************/
+uint32_t Waveform::getStream () const
+{
+  return head_.ent_head.stream;
+}
+
+/******************************************************************************/
+uint32_t Waveform::getSignature () const
+{
+  return head_.ent_head.signature;
+}
+
+/******************************************************************************/
+uint32_t Waveform::getVersion () const
+{
+  return head_.ent_head.signature & 0xFF;
+}
+
+/******************************************************************************/
+EntityType Waveform::getEntityType () const
+{
+  return static_cast<EntityType>(head_.ent_head.entity_type);
+}
+
+/******************************************************************************/
+StorageType Waveform::getStorageType () const
+{
+  return static_cast<StorageType>(head_.ent_head.storage_type);
+}
+
+/******************************************************************************/
+std::vector<unsigned char> Waveform::serialize()
+{
+  if (this->head_.ent_head.entity_type != ISMRMRD_WAVEFORM)
+  {
+    throw std::runtime_error
+      ("The header entity type does not match the Waveform class type");
+  }
+
+  if (this->head_.ent_head.storage_type != ISMRMRD_DOUBLE)
+  {
+    throw std::runtime_error
+      ("Header storage type does not match Waveform class");
+  }
+
+  size_t bytes = sizeof (WaveformHeader) + data_.size() * sizeof (double);
+
+  std::vector<unsigned char> buffer;
+  buffer.reserve (bytes);
+
+  std::copy ((unsigned char*)(&this->head_),
+             ((unsigned char*)(&this->head_)) + sizeof (WaveformHeader),
+             std::back_inserter (buffer));
+
+  std::copy ((unsigned char*)(&this->data_[0]),
+             (unsigned char*)(&this->data_[0] + data_.size()),
+             std::back_inserter(buffer));
+
+  if (buffer.size() != bytes)
+  {
+    throw std::runtime_error
+      ("Serialized Waveform buffer size does not match expected buffer size");
+  }
+
+  return buffer;
+}
+
+/******************************************************************************/
+void Waveform::deserialize (const std::vector<unsigned char>& buffer)
+{
+  if (buffer.size() < sizeof(WaveformHeader))
+  {
+    throw std::runtime_error("Buffer is too small to contain an Acquisition");
+  }
+
+  WaveformHeader* h_ptr = (WaveformHeader*)&buffer[0];
+
+  if (h_ptr->ent_head.entity_type != ISMRMRD_WAVEFORM)
+  {
+    throw std::runtime_error
+      ("The header entity type does not match the Waveform class type");
+  }
+
+  if (h_ptr->ent_head.storage_type != ISMRMRD_DOUBLE)
+  {
+    throw std::runtime_error
+      ("Header storage type does not match Waveform class");
+  }
+
+  size_t expected_bytes =
+    sizeof(WaveformHeader) + h_ptr->number_of_samples * sizeof(double);
+
+  if (expected_bytes != buffer.size())
+  {
+    std::stringstream ss;
+    ss << "Unexpected buffer length " << buffer.size()
+       << ", expected: " << expected_bytes;
+    throw std::runtime_error(ss.str());
+  }
+
+  this->setHead (*h_ptr);
+  size_t data_start = sizeof(WaveformHeader);
+  std::copy (&buffer[data_start],
+             &buffer[expected_bytes],
+             (unsigned char*)(&this->data_[0]));
+}
+
+/*******************************************************************************
+ Array class Implementation
+*******************************************************************************/
 template <typename T>
 NDArray<T>::NDArray()
 : signature_ (ISMRMRD_SIGNATURE)
@@ -1465,9 +1804,17 @@ NDArray<T>::NDArray (const std::vector<size_t>& dims)
     resize(dims);
 }
 
-template <typename T> uint32_t NDArray<T>::getSignature() const {
-    return signature_;
-};
+template <typename T>
+uint32_t NDArray<T>::getSignature() const
+{
+  return signature_;
+}
+
+template <typename T>
+uint32_t NDArray<T>::getVersion ()   const
+{
+  return signature_ & 0xFF;
+}
 
 template <typename T>
 StorageType NDArray<T>::getStorageType() const
@@ -1477,11 +1824,11 @@ StorageType NDArray<T>::getStorageType() const
 
 template <typename T> uint32_t NDArray<T>::getNDim() const {
     return dims_.size();
-};
+}
 
 template <typename T> const std::vector<size_t>& NDArray<T>::getDims() {
     return dims_;
-};
+}
 
 template <typename T> void NDArray<T>::resize(const std::vector<size_t>& dims) {
     this->dims_ = dims;
@@ -1500,34 +1847,67 @@ template <typename T> const std::vector<T>& NDArray<T>::getData() const {
     return data_;
 }
 
-template <typename T> size_t NDArray<T>::getNumberOfElements() const {
-    if (dims_.size() == 0) {
-        return 0;
-    }
+template <typename T>
+size_t NDArray<T>::getNumberOfElements() const
+{
+  if (dims_.size() == 0)
+  {
+    return 0;
+  }
 
-    size_t size = 1;
-    for (std::vector<size_t>::const_iterator it = dims_.begin(); it != dims_.end(); ++it) {
-        // This is necessary to prevent bad GCC loop optimization!
-        if (*it != 0) {
-            size *= *it;
-        }
+  size_t size = 1;
+  for (std::vector<size_t>::const_iterator it = dims_.begin(); it != dims_.end(); ++it)
+  {
+    // This is necessary to prevent bad GCC loop optimization!
+    if (*it != 0)
+    {
+      size *= *it;
     }
-    return size;
+  }
+  return size;
 }
 
-template <typename T> T& NDArray<T>::at(uint32_t x, uint32_t y, uint32_t z,
-        uint32_t w, uint32_t n, uint32_t m, uint32_t l)
+template <typename T>
+T& NDArray<T>::at
+(
+  uint32_t x,
+  uint32_t y,
+  uint32_t z,
+  uint32_t w,
+  uint32_t n,
+  uint32_t m,
+  uint32_t l
+)
 {
-    // TODO: bounds checking
-    size_t index = 0;
-    uint32_t indices[ISMRMRD_NDARRAY_MAXDIM] = {x,y,z,w,n,m,l};
-    size_t stride = 1;
-    for (uint32_t i = 0; i < dims_.size(); i++){
-        index += indices[i] * stride;
-        stride *= dims_[i];
-    }
+  size_t index = 0;
+  uint32_t indices[ISMRMRD_NDARRAY_MAXDIM] = {x,y,z,w,n,m,l};
+  size_t stride = 1;
 
-    return data_[index];
+  for (int ii = 0; ii < dims_.size(); ii++)
+  {
+    if (indices[ii] >= dims_[ii])
+    {
+      throw std::runtime_error
+        ("Call to NDArray \"at\" has data index out of bounds");
+    }
+  }
+
+  for (int ii = dims_.size(); ii < ISMRMRD_NDARRAY_MAXDIM; ii++)
+  {
+    if (indices[ii] > 0)
+    {
+      throw std::runtime_error
+        ("Call to NDArray \"at\" has extra dimensions");
+    }
+  }
+
+  for (uint32_t i = 0; i < dims_.size(); i++)
+  {
+    index += indices[i] * stride;
+    stride *= dims_[i];
+  }
+
+  return data_[index];
 }
 
 // Acquisitions

--- a/libsrc/xml.cpp
+++ b/libsrc/xml.cpp
@@ -6,50 +6,6 @@
 
 namespace ISMRMRD
 {
-
-/******************************************************************************/
-  IsmrmrdHeader::IsmrmrdHeader()
-  {
-    ent_head.stream       = ISMRMRD_HEADER_STREAM;
-    ent_head.signature    = ISMRMRD_SIGNATURE;
-    ent_head.entity_type  = ISMRMRD_XML_HEADER;
-    ent_head.storage_type = ISMRMRD_STORAGE_NONE;
-    version               = ISMRMRD_XMLHDR_VERSION;
-  }
-
-/******************************************************************************/
-
-  uint32_t IsmrmrdHeader::getStream () const
-  {
-    return ent_head.stream;
-  }
-
-/******************************************************************************/
-  uint32_t IsmrmrdHeader::getSignature () const
-  {
-    return ent_head.signature;
-  }
-
-/******************************************************************************/
-  uint32_t IsmrmrdHeader::getVersion () const
-  {
-    return ent_head.signature & 0xFF;
-  }
-
-/******************************************************************************/
-  EntityType IsmrmrdHeader::getEntityType () const
-  {
-    return static_cast<EntityType>(ent_head.entity_type);
-  }
-
-/******************************************************************************/
-  StorageType IsmrmrdHeader::getStorageType () const
-  {
-    return static_cast<StorageType>(ent_head.storage_type);
-  }
-
-/******************************************************************************/
-
   //Utility Functions for deserializing Header
   EncodingSpace parse_encoding_space(pugi::xml_node& n, const char* child) 
   {
@@ -231,7 +187,7 @@ namespace ISMRMRD
       pugi::xml_node value = nc.child("value");
 
       if (!name || !value) {
-	throw std::runtime_error("Malformed user parameter (long)");
+  throw std::runtime_error("Malformed user parameter (long)");
       }
 
       v.name = std::string(name.child_value());
@@ -254,7 +210,7 @@ namespace ISMRMRD
       pugi::xml_node value = nc.child("value");
 
       if (!name || !value) {
-	throw std::runtime_error("Malformed user parameter (double)");
+  throw std::runtime_error("Malformed user parameter (double)");
       }
 
       char buffer[10000];
@@ -280,7 +236,7 @@ namespace ISMRMRD
       pugi::xml_node value = nc.child("value");
 
       if (!name || !value) {
-	throw std::runtime_error("Malformed user parameter (string)");
+  throw std::runtime_error("Malformed user parameter (string)");
       }
 
       v.name = std::string(name.child_value());
@@ -296,17 +252,6 @@ namespace ISMRMRD
 
   //End of utility functions for deserializing header
 
-/*******************************************************************************
- virtual deserialize
-*******************************************************************************/
-  void IsmrmrdHeader::deserialize (const std::vector<unsigned char>& buffer)
-  {
-    std::string hdr (buffer.begin(), buffer.end());
-    ::ISMRMRD::deserialize (hdr.c_str(), *this);
-  }
-
-/*******************************************************************************
-*******************************************************************************/
   void deserialize(const char* xml, IsmrmrdHeader& h) 
   {
     pugi::xml_document doc;
@@ -328,200 +273,185 @@ namespace ISMRMRD
       pugi::xml_node streams = root.child("streams");
       pugi::xml_node sequenceParameters = root.child("sequenceParameters");
       pugi::xml_node userParameters = root.child("userParameters");
-      pugi::xml_node entityHeader = root.child("EntityHeader");
-
-      if (!entityHeader)
-      {
-        throw std::runtime_error ("IsmrmrdHeader EntityHeader not found");
-      }
-      else
-      {
-        EntityHeader ehdr;
-        ehdr.stream = std::atol (entityHeader.child_value ("stream"));
-        ehdr.signature = std::atol (entityHeader.child_value ("signature"));
-        ehdr.entity_type = std::atol (entityHeader.child_value ("entity_type"));
-        ehdr.storage_type = std::atol (entityHeader.child_value ("storage_type"));
-        h.ent_head = ehdr;
-      }
 
       // Parsing version
       h.version = parse_optional_long(root, "version");
       
       //Parsing experimentalConditions
       if (!experimentalConditions) {
-	throw std::runtime_error("experimentalConditions not defined in ismrmrdHeader");
+  throw std::runtime_error("experimentalConditions not defined in ismrmrdHeader");
       } else {
-	ExperimentalConditions e;
-	e.H1resonanceFrequency_Hz = std::atol(experimentalConditions.child_value("H1resonanceFrequency_Hz"));
-	h.experimentalConditions = e;
+  ExperimentalConditions e;
+  e.H1resonanceFrequency_Hz = std::atol(experimentalConditions.child_value("H1resonanceFrequency_Hz"));
+  h.experimentalConditions = e;
       }
       
       //Parsing encoding section
       if (!encoding) {
-	throw std::runtime_error("encoding section not found in ismrmrdHeader");
+  throw std::runtime_error("encoding section not found in ismrmrdHeader");
       } else {
-	while (encoding) {
-	  Encoding e;
-	  
-	  try {
-	    e.encodedSpace = parse_encoding_space(encoding,"encodedSpace");
-	    e.reconSpace = parse_encoding_space(encoding,"reconSpace");
-	  } catch (std::runtime_error& e) {
-	    std::cout << "Unable to parse encoding section: " << e.what() << std::endl;
-	    throw;
-	  }
+  while (encoding) {
+    Encoding e;
+    
+    try {
+      e.encodedSpace = parse_encoding_space(encoding,"encodedSpace");
+      e.reconSpace = parse_encoding_space(encoding,"reconSpace");
+    } catch (std::runtime_error& e) {
+      std::cout << "Unable to parse encoding section: " << e.what() << std::endl;
+      throw;
+    }
 
-	  pugi::xml_node encodingLimits = encoding.child("encodingLimits");
-	  
-	  if (!encodingLimits) {
-	    throw std::runtime_error("encodingLimits not found in encoding section");
-	  } else {
-	    e.encodingLimits.kspace_encoding_step_0 = parse_encoding_limit(encodingLimits,"kspace_encoding_step_0");
-	    e.encodingLimits.kspace_encoding_step_1 = parse_encoding_limit(encodingLimits,"kspace_encoding_step_1");
-	    e.encodingLimits.kspace_encoding_step_2 = parse_encoding_limit(encodingLimits,"kspace_encoding_step_2");
-	    e.encodingLimits.average                = parse_encoding_limit(encodingLimits,"average");
-	    e.encodingLimits.slice                  = parse_encoding_limit(encodingLimits,"slice");
-	    e.encodingLimits.contrast               = parse_encoding_limit(encodingLimits,"contrast");
-	    e.encodingLimits.phase                  = parse_encoding_limit(encodingLimits,"phase");
-	    e.encodingLimits.repetition             = parse_encoding_limit(encodingLimits,"repetition");
-	    e.encodingLimits.set                    = parse_encoding_limit(encodingLimits,"set");
-	    e.encodingLimits.segment                = parse_encoding_limit(encodingLimits,"segment");
-	  }
-	  
-	  pugi::xml_node trajectory = encoding.child("trajectory");
-	  if (!trajectory) {
-	    throw std::runtime_error("trajectory not found in encoding section");
-	  } else {
-	    e.trajectory = std::string(encoding.child_value("trajectory"));
-	  }
+    pugi::xml_node encodingLimits = encoding.child("encodingLimits");
+    
+    if (!encodingLimits) {
+      throw std::runtime_error("encodingLimits not found in encoding section");
+    } else {
+      e.encodingLimits.kspace_encoding_step_0 = parse_encoding_limit(encodingLimits,"kspace_encoding_step_0");
+      e.encodingLimits.kspace_encoding_step_1 = parse_encoding_limit(encodingLimits,"kspace_encoding_step_1");
+      e.encodingLimits.kspace_encoding_step_2 = parse_encoding_limit(encodingLimits,"kspace_encoding_step_2");
+      e.encodingLimits.average                = parse_encoding_limit(encodingLimits,"average");
+      e.encodingLimits.slice                  = parse_encoding_limit(encodingLimits,"slice");
+      e.encodingLimits.contrast               = parse_encoding_limit(encodingLimits,"contrast");
+      e.encodingLimits.phase                  = parse_encoding_limit(encodingLimits,"phase");
+      e.encodingLimits.repetition             = parse_encoding_limit(encodingLimits,"repetition");
+      e.encodingLimits.set                    = parse_encoding_limit(encodingLimits,"set");
+      e.encodingLimits.segment                = parse_encoding_limit(encodingLimits,"segment");
+    }
+    
+    pugi::xml_node trajectory = encoding.child("trajectory");
+    if (!trajectory) {
+      throw std::runtime_error("trajectory not found in encoding section");
+    } else {
+      e.trajectory = std::string(encoding.child_value("trajectory"));
+    }
 
-	  pugi::xml_node trajectoryDescription = encoding.child("trajectoryDescription");
-	  
-	  if (trajectoryDescription) {
-	    TrajectoryDescription traj;
-	    try {
-	      traj.identifier = parse_string(trajectoryDescription,"identifier");
-	      traj.userParameterLong = 
-		parse_user_parameter_long(trajectoryDescription, "userParameterLong");
-	      traj.userParameterDouble = 
-		parse_user_parameter_double(trajectoryDescription, "userParameterDouble");
-	      traj.comment = parse_optional_string(trajectoryDescription, "comment");
-	      e.trajectoryDescription = traj;
-	    } catch (std::runtime_error& e) {
-	      std::cout << "Error parsing trajectory description" << std::endl;
-	      throw;
-	    }
-	    
-	  }
+    pugi::xml_node trajectoryDescription = encoding.child("trajectoryDescription");
+    
+    if (trajectoryDescription) {
+      TrajectoryDescription traj;
+      try {
+        traj.identifier = parse_string(trajectoryDescription,"identifier");
+        traj.userParameterLong = 
+    parse_user_parameter_long(trajectoryDescription, "userParameterLong");
+        traj.userParameterDouble = 
+    parse_user_parameter_double(trajectoryDescription, "userParameterDouble");
+        traj.comment = parse_optional_string(trajectoryDescription, "comment");
+        e.trajectoryDescription = traj;
+      } catch (std::runtime_error& e) {
+        std::cout << "Error parsing trajectory description" << std::endl;
+        throw;
+      }
+      
+    }
 
-	  pugi::xml_node parallelImaging = encoding.child("parallelImaging");
-	  if (parallelImaging) {
-	    ParallelImaging info;
-	    
-	    pugi::xml_node accelerationFactor = parallelImaging.child("accelerationFactor");
-	    if (!accelerationFactor) {
-	      throw std::runtime_error("Unable to accelerationFactor section in parallelImaging");
-	    } else {
-	      info.accelerationFactor.kspace_encoding_step_1 = static_cast<unsigned short>(std::atoi(accelerationFactor.child_value("kspace_encoding_step_1")));
-	      info.accelerationFactor.kspace_encoding_step_2 = static_cast<unsigned short>(std::atoi(accelerationFactor.child_value("kspace_encoding_step_2")));
-	    }
-	    
-	    info.calibrationMode = parse_optional_string(parallelImaging,"calibrationMode");
-	    info.interleavingDimension = parse_optional_string(parallelImaging,"interleavingDimension");
-	    e.parallelImaging = info;
-	  }
+    pugi::xml_node parallelImaging = encoding.child("parallelImaging");
+    if (parallelImaging) {
+      ParallelImaging info;
+      
+      pugi::xml_node accelerationFactor = parallelImaging.child("accelerationFactor");
+      if (!accelerationFactor) {
+        throw std::runtime_error("Unable to accelerationFactor section in parallelImaging");
+      } else {
+        info.accelerationFactor.kspace_encoding_step_1 = static_cast<unsigned short>(std::atoi(accelerationFactor.child_value("kspace_encoding_step_1")));
+        info.accelerationFactor.kspace_encoding_step_2 = static_cast<unsigned short>(std::atoi(accelerationFactor.child_value("kspace_encoding_step_2")));
+      }
+      
+      info.calibrationMode = parse_optional_string(parallelImaging,"calibrationMode");
+      info.interleavingDimension = parse_optional_string(parallelImaging,"interleavingDimension");
+      e.parallelImaging = info;
+    }
 
-	  e.echoTrainLength = parse_optional_long(encoding, "echoTrainLength");
+    e.echoTrainLength = parse_optional_long(encoding, "echoTrainLength");
 
-	  h.encoding.push_back(e);
-	  encoding = encoding.next_sibling("encoding");
-	}
+    h.encoding.push_back(e);
+    encoding = encoding.next_sibling("encoding");
+  }
 
       }
 
       if (subjectInformation) {
-	SubjectInformation info;
-	info.patientName = parse_optional_string(subjectInformation, "patientName");
-	info.patientWeight_kg = parse_optional_float(subjectInformation, "patientWeight_kg");
-	info.patientID = parse_optional_string(subjectInformation, "patientID");
-	info.patientBirthdate = parse_optional_string(subjectInformation, "patientBirthdate");
-	info.patientGender = parse_optional_string(subjectInformation, "patientGender");
-	h.subjectInformation = info;
+  SubjectInformation info;
+  info.patientName = parse_optional_string(subjectInformation, "patientName");
+  info.patientWeight_kg = parse_optional_float(subjectInformation, "patientWeight_kg");
+  info.patientID = parse_optional_string(subjectInformation, "patientID");
+  info.patientBirthdate = parse_optional_string(subjectInformation, "patientBirthdate");
+  info.patientGender = parse_optional_string(subjectInformation, "patientGender");
+  h.subjectInformation = info;
       }
 
       if (studyInformation) {
-	StudyInformation info;
-	info.studyDate = parse_optional_string(studyInformation,"studyDate");
-	info.studyTime = parse_optional_string(studyInformation,"studyTime");
-	info.studyID = parse_optional_string(studyInformation,"studyID");
-	info.accessionNumber = parse_optional_long(studyInformation,"accessionNumber");
-	info.referringPhysicianName = parse_optional_string(studyInformation,"referringPhysicianName");
-	info.studyDescription = parse_optional_string(studyInformation,"studyDescription");
-	info.studyInstanceUID = parse_optional_string(studyInformation,"studyInstanceUID");
-	h.studyInformation = info;
+  StudyInformation info;
+  info.studyDate = parse_optional_string(studyInformation,"studyDate");
+  info.studyTime = parse_optional_string(studyInformation,"studyTime");
+  info.studyID = parse_optional_string(studyInformation,"studyID");
+  info.accessionNumber = parse_optional_long(studyInformation,"accessionNumber");
+  info.referringPhysicianName = parse_optional_string(studyInformation,"referringPhysicianName");
+  info.studyDescription = parse_optional_string(studyInformation,"studyDescription");
+  info.studyInstanceUID = parse_optional_string(studyInformation,"studyInstanceUID");
+  h.studyInformation = info;
       }
 
       if (measurementInformation) {
-	MeasurementInformation info;
-	info.measurementID = parse_optional_string(measurementInformation,"measurementID");
-	info.seriesDate = parse_optional_string(measurementInformation, "seriesDate");
-	info.seriesTime = parse_optional_string(measurementInformation, "seriesTime");
-	info.patientPosition = parse_string(measurementInformation, "patientPosition");
-	info.initialSeriesNumber = parse_optional_long(measurementInformation, "initialSeriesNumber");
-	info.protocolName = parse_optional_string(measurementInformation, "protocolName");
-	info.seriesDescription = parse_optional_string(measurementInformation, "seriesDescription");
-	
-	pugi::xml_node measurementDependency = measurementInformation.child("measurementDependency");
-	while (measurementDependency) {
-	  try {
-	    MeasurementDependency d;
-	    d.measurementID = parse_string(measurementDependency,"measurementID");
-	    d.dependencyType = parse_string(measurementDependency,"dependencyType");
-	    info.measurementDependency.push_back(d);
-	  } catch (std::runtime_error& e) {
-	    std::cout << "Error parsing measurement dependency: " << e.what() << std::endl;
-	    throw;
-	  } 
-	  measurementDependency = measurementDependency.next_sibling("measurementDependency");
-	}
+  MeasurementInformation info;
+  info.measurementID = parse_optional_string(measurementInformation,"measurementID");
+  info.seriesDate = parse_optional_string(measurementInformation, "seriesDate");
+  info.seriesTime = parse_optional_string(measurementInformation, "seriesTime");
+  info.patientPosition = parse_string(measurementInformation, "patientPosition");
+  info.initialSeriesNumber = parse_optional_long(measurementInformation, "initialSeriesNumber");
+  info.protocolName = parse_optional_string(measurementInformation, "protocolName");
+  info.seriesDescription = parse_optional_string(measurementInformation, "seriesDescription");
+  
+  pugi::xml_node measurementDependency = measurementInformation.child("measurementDependency");
+  while (measurementDependency) {
+    try {
+      MeasurementDependency d;
+      d.measurementID = parse_string(measurementDependency,"measurementID");
+      d.dependencyType = parse_string(measurementDependency,"dependencyType");
+      info.measurementDependency.push_back(d);
+    } catch (std::runtime_error& e) {
+      std::cout << "Error parsing measurement dependency: " << e.what() << std::endl;
+      throw;
+    } 
+    measurementDependency = measurementDependency.next_sibling("measurementDependency");
+  }
 
-	info.seriesInstanceUIDRoot = parse_optional_string(measurementInformation,"seriesInstanceUIDRoot");
-	info.frameOfReferenceUID = parse_optional_string(measurementInformation,"frameOfReferenceUID");
+  info.seriesInstanceUIDRoot = parse_optional_string(measurementInformation,"seriesInstanceUIDRoot");
+  info.frameOfReferenceUID = parse_optional_string(measurementInformation,"frameOfReferenceUID");
 
-	//This part of the schema is totally messed up and needs to be fixed, but for now we will just read it. 
-	pugi::xml_node ri = measurementInformation.child("referencedImageSequence");
-	if (ri) {
-	  pugi::xml_node ric = ri.child("referencedSOPInstanceUID");
-	  while (ric) {
-	    ReferencedImageSequence r;
-	    r.referencedSOPInstanceUID = ric.child_value();
-	    info.referencedImageSequence.push_back(r);
-	    ric = ric.next_sibling("referencedSOPInstanceUID");
-	  }
-	}
+  //This part of the schema is totally messed up and needs to be fixed, but for now we will just read it. 
+  pugi::xml_node ri = measurementInformation.child("referencedImageSequence");
+  if (ri) {
+    pugi::xml_node ric = ri.child("referencedSOPInstanceUID");
+    while (ric) {
+      ReferencedImageSequence r;
+      r.referencedSOPInstanceUID = ric.child_value();
+      info.referencedImageSequence.push_back(r);
+      ric = ric.next_sibling("referencedSOPInstanceUID");
+    }
+  }
 
-	h.measurementInformation = info;
+  h.measurementInformation = info;
       }
 
       if (acquisitionSystemInformation) {
-	AcquisitionSystemInformation info;
-	info.systemVendor = parse_optional_string(acquisitionSystemInformation, "systemVendor");
-	info.systemModel = parse_optional_string(acquisitionSystemInformation, "systemModel");
-	info.systemFieldStrength_T = parse_optional_float(acquisitionSystemInformation, "systemFieldStrength_T");
-	info.relativeReceiverNoiseBandwidth = parse_optional_float(acquisitionSystemInformation, "relativeReceiverNoiseBandwidth");
-	info.receiverChannels = parse_optional_ushort(acquisitionSystemInformation, "receiverChannels");
-	pugi::xml_node coilLabel = acquisitionSystemInformation.child("coilLabel");
-	while (coilLabel) {
-	  CoilLabel l;
-	  l.coilNumber = std::atoi(coilLabel.child_value("coilNumber"));
-	  l.coilName = parse_string(coilLabel, "coilName");
-	  info.coilLabel.push_back(l);
-	  coilLabel = coilLabel.next_sibling("coilLabel");
-	}
-	info.institutionName = parse_optional_string(acquisitionSystemInformation, "institutionName");
-	info.stationName = parse_optional_string(acquisitionSystemInformation, "stationName");
+  AcquisitionSystemInformation info;
+  info.systemVendor = parse_optional_string(acquisitionSystemInformation, "systemVendor");
+  info.systemModel = parse_optional_string(acquisitionSystemInformation, "systemModel");
+  info.systemFieldStrength_T = parse_optional_float(acquisitionSystemInformation, "systemFieldStrength_T");
+  info.relativeReceiverNoiseBandwidth = parse_optional_float(acquisitionSystemInformation, "relativeReceiverNoiseBandwidth");
+  info.receiverChannels = parse_optional_ushort(acquisitionSystemInformation, "receiverChannels");
+  pugi::xml_node coilLabel = acquisitionSystemInformation.child("coilLabel");
+  while (coilLabel) {
+    CoilLabel l;
+    l.coilNumber = std::atoi(coilLabel.child_value("coilNumber"));
+    l.coilName = parse_string(coilLabel, "coilName");
+    info.coilLabel.push_back(l);
+    coilLabel = coilLabel.next_sibling("coilLabel");
+  }
+  info.institutionName = parse_optional_string(acquisitionSystemInformation, "institutionName");
+  info.stationName = parse_optional_string(acquisitionSystemInformation, "stationName");
 
-	h.acquisitionSystemInformation = info;
+  h.acquisitionSystemInformation = info;
       }
 
     if (streams) {
@@ -529,7 +459,7 @@ namespace ISMRMRD
     }
 
       if (sequenceParameters) {
-	SequenceParameters p;
+  SequenceParameters p;
 
     std::vector<float> r;
     r = parse_vector_float(sequenceParameters, "TR");
@@ -549,16 +479,16 @@ namespace ISMRMRD
     r = parse_vector_float(sequenceParameters, "echo_spacing");
     if (!r.empty()) p.echo_spacing = r;
 
-	h.sequenceParameters = p;
+  h.sequenceParameters = p;
       }
 
       if (userParameters) {
-	UserParameters p;
- 	p.userParameterLong = parse_user_parameter_long(userParameters,"userParameterLong");
- 	p.userParameterDouble = parse_user_parameter_double(userParameters,"userParameterDouble");
- 	p.userParameterString = parse_user_parameter_string(userParameters,"userParameterString");
- 	p.userParameterBase64 = parse_user_parameter_string(userParameters,"userParameterBase64");
-	h.userParameters = p;
+  UserParameters p;
+   p.userParameterLong = parse_user_parameter_long(userParameters,"userParameterLong");
+   p.userParameterDouble = parse_user_parameter_double(userParameters,"userParameterDouble");
+   p.userParameterString = parse_user_parameter_string(userParameters,"userParameterString");
+   p.userParameterBase64 = parse_user_parameter_string(userParameters,"userParameterBase64");
+  h.userParameters = p;
       }
     } else {
       throw std::runtime_error("Root node 'ismrmrdHeader' not found");
@@ -703,7 +633,7 @@ namespace ISMRMRD
 
   template <class T> 
   void append_user_parameter(pugi::xml_node& n, const char* child, 
-			     const std::vector<T>& v) 
+           const std::vector<T>& v) 
   {
     for (size_t i = 0; i < v.size(); i++) {
       pugi::xml_node n2 = n.append_child(child);
@@ -714,20 +644,6 @@ namespace ISMRMRD
 
   //End utility functions for serialization
 
-/*******************************************************************************
- virtual serialize
-*******************************************************************************/
-std::vector<unsigned char> IsmrmrdHeader::serialize()
-{
-  std::stringstream str;
-  ::ISMRMRD::serialize (*this, str);
-  std::string hdr = str.str();
-  std::vector<unsigned char> buffer (hdr.begin(), hdr.end());
-  return buffer;
-}
-
-/*******************************************************************************
-*******************************************************************************/
   void serialize(const IsmrmrdHeader& h, std::ostream& o)
   {
     pugi::xml_document doc;
@@ -748,13 +664,6 @@ std::vector<unsigned char> IsmrmrdHeader::serialize()
     
     a = root.append_attribute("xsi:schemaLocation");
     a.set_value("http://www.ismrm.org/ISMRMRD ismrmrd.xsd");
-
-    n1 = root.append_child();
-    n1.set_name ("EntityHeader");
-    append_node (n1, "stream", (long)h.ent_head.stream);
-    append_node (n1, "signature", (long)h.ent_head.signature);
-    append_node (n1, "entity_type", (long)h.ent_head.entity_type);
-    append_node (n1, "storage_type", (long)h.ent_head.storage_type);
 
     if (h.version) {
       if (*h.version != ISMRMRD_XMLHDR_VERSION) {
@@ -797,10 +706,10 @@ std::vector<unsigned char> IsmrmrdHeader::serialize()
       append_optional_node(n1,"seriesDescription",h.measurementInformation->seriesDescription);
 
       for (size_t i = 0; i < h.measurementInformation->measurementDependency.size(); i++) {
-	n2 = n1.append_child();
-	n2.set_name("measurementDependency");
-	append_node(n2,"dependencyType",h.measurementInformation->measurementDependency[i].dependencyType);
-	append_node(n2,"measurementID",h.measurementInformation->measurementDependency[i].measurementID);
+  n2 = n1.append_child();
+  n2.set_name("measurementDependency");
+  append_node(n2,"dependencyType",h.measurementInformation->measurementDependency[i].dependencyType);
+  append_node(n2,"measurementID",h.measurementInformation->measurementDependency[i].measurementID);
       }
       
       append_optional_node(n1,"seriesInstanceUIDRoot",h.measurementInformation->seriesInstanceUIDRoot);
@@ -808,10 +717,10 @@ std::vector<unsigned char> IsmrmrdHeader::serialize()
       
       //TODO: Sort out stuff with this referenced image sequence. This is all messed up. 
       if (h.measurementInformation->referencedImageSequence.size()) {
-	n2 = n1.append_child("referencedImageSequence");
-	for (size_t i = 0; i < h.measurementInformation->referencedImageSequence.size(); i++) {
-	  append_node(n2,"referencedSOPInstanceUID", h.measurementInformation->referencedImageSequence[i].referencedSOPInstanceUID);
-	}
+  n2 = n1.append_child("referencedImageSequence");
+  for (size_t i = 0; i < h.measurementInformation->referencedImageSequence.size(); i++) {
+    append_node(n2,"referencedSOPInstanceUID", h.measurementInformation->referencedImageSequence[i].referencedSOPInstanceUID);
+  }
       }
       
 
@@ -826,10 +735,10 @@ std::vector<unsigned char> IsmrmrdHeader::serialize()
       append_optional_node(n1,"relativeReceiverNoiseBandwidth",h.acquisitionSystemInformation->relativeReceiverNoiseBandwidth);
       append_optional_node(n1,"receiverChannels",h.acquisitionSystemInformation->receiverChannels);
       for (size_t i = 0; i < h.acquisitionSystemInformation->coilLabel.size(); i++) {
-	n2 = n1.append_child();
-	n2.set_name("coilLabel");
-	append_node(n2,"coilNumber",h.acquisitionSystemInformation->coilLabel[i].coilNumber);
-	append_node(n2,"coilName",h.acquisitionSystemInformation->coilLabel[i].coilName);
+  n2 = n1.append_child();
+  n2.set_name("coilLabel");
+  append_node(n2,"coilNumber",h.acquisitionSystemInformation->coilLabel[i].coilNumber);
+  append_node(n2,"coilName",h.acquisitionSystemInformation->coilLabel[i].coilName);
       }
       append_optional_node(n1,"institutionName",h.acquisitionSystemInformation->institutionName);
       append_optional_node(n1,"stationName",h.acquisitionSystemInformation->stationName);
@@ -861,20 +770,20 @@ std::vector<unsigned char> IsmrmrdHeader::serialize()
       append_node(n1,"trajectory",h.encoding[i].trajectory);
       
       if (h.encoding[i].trajectoryDescription) {
-	n2 = n1.append_child("trajectoryDescription");
-	append_node(n2,"identifier",h.encoding[i].trajectoryDescription->identifier);
-	append_user_parameter(n2,"userParameterLong",h.encoding[i].trajectoryDescription->userParameterLong); 
-	append_user_parameter(n2,"userParameterDouble",h.encoding[i].trajectoryDescription->userParameterDouble); 
-	append_optional_node(n2,"comment",h.encoding[i].trajectoryDescription->comment);
+  n2 = n1.append_child("trajectoryDescription");
+  append_node(n2,"identifier",h.encoding[i].trajectoryDescription->identifier);
+  append_user_parameter(n2,"userParameterLong",h.encoding[i].trajectoryDescription->userParameterLong); 
+  append_user_parameter(n2,"userParameterDouble",h.encoding[i].trajectoryDescription->userParameterDouble); 
+  append_optional_node(n2,"comment",h.encoding[i].trajectoryDescription->comment);
       }
 
       if (h.encoding[i].parallelImaging) {
-	n2 = n1.append_child("parallelImaging");
-	n3 = n2.append_child("accelerationFactor");
-	append_node(n3,"kspace_encoding_step_1",h.encoding[i].parallelImaging->accelerationFactor.kspace_encoding_step_1);
-	append_node(n3,"kspace_encoding_step_2",h.encoding[i].parallelImaging->accelerationFactor.kspace_encoding_step_2);
-	append_optional_node(n2, "calibrationMode", h.encoding[i].parallelImaging->calibrationMode);
-	append_optional_node(n2, "interleavingDimension", h.encoding[i].parallelImaging->interleavingDimension);
+  n2 = n1.append_child("parallelImaging");
+  n3 = n2.append_child("accelerationFactor");
+  append_node(n3,"kspace_encoding_step_1",h.encoding[i].parallelImaging->accelerationFactor.kspace_encoding_step_1);
+  append_node(n3,"kspace_encoding_step_2",h.encoding[i].parallelImaging->accelerationFactor.kspace_encoding_step_2);
+  append_optional_node(n2, "calibrationMode", h.encoding[i].parallelImaging->calibrationMode);
+  append_optional_node(n2, "interleavingDimension", h.encoding[i].parallelImaging->interleavingDimension);
       }
 
       append_optional_node(n1, "echoTrainLength", h.encoding[i].echoTrainLength);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(test_ismrmrd
     test_xml.cpp
     test_meta.cpp
     test_waveform.cpp
+    test_text.cpp
     ${ISMRMRD_DATASET_TEST_SOURCES}
     )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(test_ismrmrd
     test_quaternions.cpp
     test_xml.cpp
     test_meta.cpp
+    test_waveform.cpp
     ${ISMRMRD_DATASET_TEST_SOURCES}
     )
 

--- a/tests/test_acquisitions.cpp
+++ b/tests/test_acquisitions.cpp
@@ -16,18 +16,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE (acquisition_create, T, test_types)
 {
   Acquisition<T>    acq;
   AcquisitionHeader head = acq.getHead();
-  EntityHeader      ehdr = head.ent_head;
   EncodingCounters  ec   = head.idx;
-
-  size_t ehdr_size = sizeof (uint32_t) * 4;
-  BOOST_CHECK_EQUAL (sizeof (ehdr), ehdr_size);
 
   size_t ec_size = sizeof (uint32_t) * (10 + ISMRMRD_USER_INTS);
   BOOST_CHECK_EQUAL (sizeof (ec), ec_size);
 
   // Check that header is of expected size
-  size_t expected_size = sizeof (ehdr) +
-                         sizeof (uint32_t) * (10 + ISMRMRD_PHYS_STAMPS) +
+  size_t expected_size = sizeof (uint32_t) * (10 + ISMRMRD_PHYS_STAMPS) +
                          sizeof (int32_t)  * ISMRMRD_USER_INTS +
                          sizeof (uint64_t) * (2 + ISMRMRD_CHANNEL_MASKS) +
                          sizeof (float)    * (ISMRMRD_POSITION_LENGTH * 2 +
@@ -326,11 +321,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE (acquisition_getters_setters, T, test_types)
   }
 
 
-  acq.setStream (123);
-  BOOST_CHECK_EQUAL (acq.getStream(), 123);
-
-  BOOST_CHECK_EQUAL (acq.getSignature(), ISMRMRD_SIGNATURE);
-  BOOST_CHECK_EQUAL (acq.getVersion(), ISMRMRD_VERSION_MAJOR);
   BOOST_CHECK_EQUAL (acq.getEntityType(), ISMRMRD_MRACQUISITION);
   BOOST_CHECK_EQUAL (acq.getStorageType(), get_storage_type<T>());
 
@@ -374,10 +364,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE (acquisition_serialize, T, test_types)
 
 static void check_header (const AcquisitionHeader& chead)
 {
-  BOOST_CHECK_EQUAL (chead.ent_head.stream, 0);
-  BOOST_CHECK_EQUAL (chead.ent_head.signature, ISMRMRD_SIGNATURE);
-  BOOST_CHECK_EQUAL (chead.ent_head.entity_type, ISMRMRD_MRACQUISITION);
-
   BOOST_CHECK_EQUAL (chead.time_stamp, 0);
   BOOST_CHECK_EQUAL (chead.flags, 0);
   BOOST_CHECK_EQUAL (chead.scan_counter, 0);

--- a/tests/test_acquisitions.cpp
+++ b/tests/test_acquisitions.cpp
@@ -49,6 +49,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE (acquisition_copy, T, test_types)
   check_header (acq2.getHead());
 
   BOOST_CHECK (acq1.getHead() == acq2.getHead());
+
+  Acquisition<T> acq3;
+  acq3.setHead (acq1.getHead());
+  BOOST_CHECK (acq3.getHead() == acq2.getHead());
 }
 
 
@@ -326,6 +330,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE (acquisition_getters_setters, T, test_types)
   BOOST_CHECK_EQUAL (acq.getStream(), 123);
 
   BOOST_CHECK_EQUAL (acq.getSignature(), ISMRMRD_SIGNATURE);
+  BOOST_CHECK_EQUAL (acq.getVersion(), ISMRMRD_VERSION_MAJOR);
   BOOST_CHECK_EQUAL (acq.getEntityType(), ISMRMRD_MRACQUISITION);
   BOOST_CHECK_EQUAL (acq.getStorageType(), get_storage_type<T>());
 

--- a/tests/test_images.cpp
+++ b/tests/test_images.cpp
@@ -17,14 +17,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE (image_create, T, test_types)
 {
   Image<T> img;
   ImageHeader head = img.getHead();
-  EntityHeader ehdr = head.ent_head;
 
   // Check that header is of expected size
-  size_t ehdr_size = sizeof (uint32_t) * 4;
-  BOOST_CHECK_EQUAL (sizeof (ehdr), ehdr_size);
-
-  size_t expected_size = sizeof(ehdr) +
-                         sizeof(uint32_t) * ISMRMRD_PHYS_STAMPS +
+  size_t expected_size = sizeof(uint32_t) * ISMRMRD_PHYS_STAMPS +
                          sizeof(uint32_t) * 14 +
                          sizeof(int32_t) * ISMRMRD_USER_INTS +
                          sizeof(uint64_t) * 2 +
@@ -267,12 +262,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE (image_getters_setters, T, test_types)
   img.getAttributeString (temp1);
   BOOST_CHECK_EQUAL (std::strcmp (temp1.data(), temp.data()), 0);
 
-
-  img.setStream (123);
-  BOOST_CHECK_EQUAL (img.getStream(), 123);
-
-  BOOST_CHECK_EQUAL (img.getSignature(), ISMRMRD_SIGNATURE);
-  BOOST_CHECK_EQUAL (img.getVersion(), 2); //TODO: Use ISMRMRD_VERSION_MAJOR?
   BOOST_CHECK_EQUAL (img.getEntityType(), ISMRMRD_IMAGE);
   BOOST_CHECK_EQUAL (img.getStorageType(), get_storage_type<T>());
 }
@@ -313,10 +302,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE (image_serialize, T, test_types)
 
 static void check_header (const ImageHeader& chead)
 {
-  BOOST_CHECK_EQUAL (chead.ent_head.stream, 0);
-  BOOST_CHECK_EQUAL (chead.ent_head.signature, ISMRMRD_SIGNATURE);
-  BOOST_CHECK_EQUAL (chead.ent_head.entity_type, ISMRMRD_IMAGE);
-
   BOOST_CHECK_EQUAL (chead.time_stamp, 0);
   BOOST_CHECK_EQUAL (chead.flags, 0);
 

--- a/tests/test_images.cpp
+++ b/tests/test_images.cpp
@@ -6,130 +6,383 @@
 
 using namespace ISMRMRD;
 
-typedef boost::mpl::list<uint16_t, int16_t, uint32_t, int32_t, float,
-                         double, std::complex<float>, std::complex<double> > test_types;
+typedef boost::mpl::list<uint16_t, int16_t, uint32_t, int32_t, float, double,
+                         std::complex<float>, std::complex<double> > test_types;
 
 BOOST_AUTO_TEST_SUITE(Images)
 
-static void check_header(const ImageHeader& head);
+static void check_header (const ImageHeader& head);
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(image_create, T, test_types)
+BOOST_AUTO_TEST_CASE_TEMPLATE (image_create, T, test_types)
 {
-    Image<T> img;
-    ImageHeader head = img.getHead();
+  Image<T> img;
+  ImageHeader head = img.getHead();
+  EntityHeader ehdr = head.ent_head;
 
-    // Check that header is of expected size
-    size_t expected_size = 21 * sizeof(uint32_t) +
-            ISMRMRD_USER_INTS * sizeof(int32_t) +
-            2 * sizeof(uint64_t) +
-            ((2 * ISMRMRD_POSITION_LENGTH) + (3 * ISMRMRD_DIRECTION_LENGTH) +
-                    3 + ISMRMRD_USER_FLOATS) * sizeof(float);
+  // Check that header is of expected size
+  size_t ehdr_size = sizeof (uint32_t) * 4;
+  BOOST_CHECK_EQUAL (sizeof (ehdr), ehdr_size);
 
-    BOOST_CHECK_EQUAL(sizeof(head), expected_size);
+  size_t expected_size = sizeof(ehdr) +
+                         sizeof(uint32_t) * ISMRMRD_PHYS_STAMPS +
+                         sizeof(uint32_t) * 14 +
+                         sizeof(int32_t) * ISMRMRD_USER_INTS +
+                         sizeof(uint64_t) * 2 +
+                         sizeof(float) * 3 +
+                         sizeof(float) * ISMRMRD_POSITION_LENGTH * 2 +
+                         sizeof(float) * ISMRMRD_DIRECTION_LENGTH * 3 +
+                         sizeof(float) * ISMRMRD_USER_FLOATS;
 
-    // Check that header is initialized properly
-    check_header(head);
+  BOOST_CHECK_EQUAL (sizeof(head), expected_size);
+
+  // Check that header is initialized properly
+  check_header (head);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(image_copy, T, test_types)
+BOOST_AUTO_TEST_CASE_TEMPLATE (image_copy, T, test_types)
 {
-    Image<T> img1;
-    check_header(img1.getHead());
-    Image<T> img2(img1);
-    check_header(img2.getHead());
+  Image<T> img1;
+  check_header (img1.getHead());
+  Image<T> img2 (img1);
+  check_header (img2.getHead());
 
-    BOOST_CHECK(img1.getHead() == img2.getHead());
+  BOOST_CHECK (img1.getHead() == img2.getHead());
+
+  Image<T> img3;
+  img3.setHead (img1.getHead());
+  BOOST_CHECK (img3.getHead() == img1.getHead());
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(image_getters_setters, T, test_types)
+BOOST_AUTO_TEST_CASE_TEMPLATE (image_getters_setters, T, test_types)
 {
-    Image<T> img;
+  Image<T> img;
 
-    // TODO: implement
+  img.setMatrixSizeX (0);
+  BOOST_CHECK_EQUAL (img.getMatrixSizeX(), 0);
+  BOOST_CHECK_EQUAL (img.getNumberOfElements(), 0);
+
+  img.setMatrixSizeX (42);
+  BOOST_CHECK_EQUAL (img.getMatrixSizeX(), 42);
+  BOOST_CHECK_EQUAL (img.getNumberOfElements(), 42);
+
+  img.setMatrixSizeY (142);
+  BOOST_CHECK_EQUAL (img.getMatrixSizeY(), 142);
+  BOOST_CHECK_EQUAL (img.getNumberOfElements(), 42 * 142);
+
+  img.setMatrixSizeZ (32);
+  BOOST_CHECK_EQUAL (img.getMatrixSizeZ(), 32);
+  BOOST_CHECK_EQUAL (img.getNumberOfElements(), 42 * 142 * 32);
+
+  img.setNumberOfChannels (8);
+  BOOST_CHECK_EQUAL (img.getNumberOfChannels(), 8);
+  BOOST_CHECK_EQUAL (img.getNumberOfElements(), 42 * 142 * 32 * 8);
+
+  // Field of view
+  img.setFieldOfView (320.0, 480.0, 16.0);
+  BOOST_CHECK_CLOSE (img.getFieldOfViewX(), 320.0, 0.01);
+  BOOST_CHECK_CLOSE (img.getFieldOfViewY(), 480.0, 0.01);
+  BOOST_CHECK_CLOSE (img.getFieldOfViewZ(), 16.0, 0.01);
+
+  img.setFieldOfViewX (147.5);
+  BOOST_CHECK_CLOSE (img.getFieldOfViewX(), 147.5, 0.01);
+
+  img.setFieldOfViewY (123.4);
+  BOOST_CHECK_CLOSE (img.getFieldOfViewY(), 123.4, 0.01);
+
+  img.setFieldOfViewZ (43.2);
+  BOOST_CHECK_CLOSE (img.getFieldOfViewZ(), 43.2, 0.01);
+
+  // Positions and orientations
+  img.setPosition (123.4, 234.5, 345.6);
+  BOOST_CHECK_CLOSE (img.getPositionX(), 123.4, 0.01);
+  BOOST_CHECK_CLOSE (img.getPositionY(), 234.5, 0.01);
+  BOOST_CHECK_CLOSE (img.getPositionZ(), 345.6, 0.01);
+  img.setPositionX (345.6);
+  BOOST_CHECK_CLOSE (img.getPositionX(), 345.6, 0.01);
+  img.setPositionY (123.4);
+  BOOST_CHECK_CLOSE (img.getPositionY(), 123.4, 0.01);
+  img.setPositionZ (234.5);
+  BOOST_CHECK_CLOSE (img.getPositionZ(), 234.5, 0.01);
+
+  img.setReadDirection (3.21, 4.32, 5.43);
+  BOOST_CHECK_CLOSE (img.getReadDirectionX(), 3.21, 0.01);
+  BOOST_CHECK_CLOSE (img.getReadDirectionY(), 4.32, 0.01);
+  BOOST_CHECK_CLOSE (img.getReadDirectionZ(), 5.43, 0.01);
+  img.setReadDirectionX (7.12);
+  BOOST_CHECK_CLOSE (img.getReadDirectionX(), 7.12, 0.01);
+  img.setReadDirectionY (5.98);
+  BOOST_CHECK_CLOSE (img.getReadDirectionY(), 5.98, 0.01);
+  img.setReadDirectionZ (8.76);
+  BOOST_CHECK_CLOSE (img.getReadDirectionZ(), 8.76, 0.01);
+
+  img.setPhaseDirection (5.23, 3.93, 4.19);
+  BOOST_CHECK_CLOSE (img.getPhaseDirectionX(), 5.23, 0.01);
+  BOOST_CHECK_CLOSE (img.getPhaseDirectionY(), 3.93, 0.01);
+  BOOST_CHECK_CLOSE (img.getPhaseDirectionZ(), 4.19, 0.01);
+  img.setPhaseDirectionX (5.01);
+  BOOST_CHECK_CLOSE (img.getPhaseDirectionX(), 5.01, 0.01);
+  img.setPhaseDirectionY (2.19);
+  BOOST_CHECK_CLOSE (img.getPhaseDirectionY(), 2.19, 0.01);
+  img.setPhaseDirectionZ (8.91);
+  BOOST_CHECK_CLOSE (img.getPhaseDirectionZ(), 8.91, 0.01);
+
+  img.setSliceDirection (6.79, 8.39, 4.89);
+  BOOST_CHECK_CLOSE (img.getSliceDirectionX(), 6.79, 0.01);
+  BOOST_CHECK_CLOSE (img.getSliceDirectionY(), 8.39, 0.01);
+  BOOST_CHECK_CLOSE (img.getSliceDirectionZ(), 4.89, 0.01);
+  img.setSliceDirectionX (7.26);
+  BOOST_CHECK_CLOSE (img.getSliceDirectionX(), 7.26, 0.01);
+  img.setSliceDirectionY (0.62);
+  BOOST_CHECK_CLOSE (img.getSliceDirectionY(), 0.62, 0.01);
+  img.setSliceDirectionZ ( 2.84);
+  BOOST_CHECK_CLOSE (img.getSliceDirectionZ(),  2.84, 0.01);
+
+  img.setPatientTablePosition (7.31, 1.23, 2.08);
+  BOOST_CHECK_CLOSE (img.getPatientTablePositionX(), 7.31, 0.01);
+  BOOST_CHECK_CLOSE (img.getPatientTablePositionY(), 1.23, 0.01);
+  BOOST_CHECK_CLOSE (img.getPatientTablePositionZ(), 2.08, 0.01);
+  img.setPatientTablePositionX (2.08);
+  BOOST_CHECK_CLOSE (img.getPatientTablePositionX(), 2.08, 0.01);
+  img.setPatientTablePositionY (8.54);
+  BOOST_CHECK_CLOSE (img.getPatientTablePositionY(), 8.54, 0.01);
+  img.setPatientTablePositionZ (4.93);
+  BOOST_CHECK_CLOSE (img.getPatientTablePositionZ(), 4.93, 0.01);
+
+  // Counters and labels
+  img.setAverage (67);
+  BOOST_CHECK_EQUAL (img.getAverage(), 67);
+
+  img.setSlice (43);
+  BOOST_CHECK_EQUAL (img.getSlice(), 43);
+
+  img.setContrast (456);
+  BOOST_CHECK_EQUAL (img.getContrast(), 456);
+
+  img.setPhase (531);
+  BOOST_CHECK_EQUAL (img.getPhase(), 531);
+
+  img.setRepetition (6);
+  BOOST_CHECK_EQUAL (img.getRepetition(), 6);
+
+  img.setSet (159);
+  BOOST_CHECK_EQUAL (img.getSet(), 159);
+
+  img.setTimeStamp (1234567890);
+  BOOST_CHECK_EQUAL (img.getTimeStamp(), 1234567890);
+
+  for (int idx = 0; idx < ISMRMRD_PHYS_STAMPS; idx++)
+  {
+    img.setPhysiologyTimeStamp (idx, 54637 * (idx + 1));
+    BOOST_CHECK_EQUAL (img.getPhysiologyTimeStamp (idx), 54637 * (idx + 1));
+  }
+
+  img.setImageType (3);
+  BOOST_CHECK_EQUAL (img.getImageType(), 3);
+
+  img.setImageIndex (2);
+  BOOST_CHECK_EQUAL (img.getImageIndex(), 2);
+
+  img.setImageSeriesIndex (4);
+  BOOST_CHECK_EQUAL (img.getImageSeriesIndex(), 4);
+
+  // User parameters
+  for (int ii = 0; ii < ISMRMRD_USER_FLOATS; ii++)
+  {
+    img.setUserFloat (ii, ii + 19.54);
+    BOOST_CHECK_CLOSE (img.getUserFloat (ii), ii + 19.54, 0.01);
+  }
+
+  for (int ii = 0; ii < ISMRMRD_USER_INTS; ii++)
+  {
+    img.setUserInt(ii, ii + 37);
+    BOOST_CHECK_EQUAL (img.getUserInt (ii), ii + 37);
+  }
+
+  // Flags
+  uint64_t val = 0x23456789ABCDEF01;
+  img.setFlags (val);
+  BOOST_CHECK_EQUAL (img.getFlags(), val);
+
+  img.clearAllFlags ();
+  BOOST_CHECK_EQUAL (img.getFlags(), 0);
+
+  val = 0x6000;
+  BOOST_CHECK_EQUAL (img.isFlagSet (val), 0);
+
+  img.setFlag (val);
+  BOOST_CHECK_EQUAL (img.isFlagSet (val), 1);
+
+  img.clearFlag (val);
+  BOOST_CHECK_EQUAL (img.isFlagSet (val), 0);
+
+  // Data set/get
+  img.resize (42, 86, 16, 4);
+  std::vector<T> data (42 * 86 * 16 * 4);
+  for (int ii = 0; ii < 42 * 86 * 16 * 4; ii++)
+  {
+    data[ii] = (T)(ii + 52);
+  }
+
+  for (int ix = 0; ix < 42; ix++)
+  {
+    for (int iy = 0; iy < 86; iy++)
+    {
+      for (int iz = 0; iz < 16; iz++)
+      {
+        for (int ic = 0; ic < 4; ic++)
+        {
+          size_t idx = ix + (42 * iy) + (42 * 86 * iz) + (42 * 86 * 16 * ic);
+          img.at (ix, iy, iz, ic) = data[idx];
+        }
+      }
+    }
+  }
+
+  std::vector<T> data1;
+  data1 = img.getData();
+
+  for (int ix = 0; ix < 42; ix++)
+  {
+    for (int iy = 0; iy < 86; iy++)
+    {
+      for (int iz = 0; iz < 16; iz++)
+      {
+        for (int ic = 0; ic < 4; ic++)
+        {
+          size_t idx = ix + (42 * iy) + (42 * 86 * iz) + (42 * 86 * 16 * ic);
+          BOOST_CHECK_EQUAL (data[idx], data1[idx]);
+        }
+      }
+    }
+  }
+
+  // Attribute string
+  std::string temp ("This is a test string with spaces");
+  img.setAttributeString (temp);
+  BOOST_CHECK_EQUAL (img.getAttributeStringLength(), temp.size());
+  BOOST_CHECK_EQUAL (std::strcmp (img.getAttributeString().data(),
+                                  temp.data()), 0);
+
+  std::string temp1;
+  img.getAttributeString (temp1);
+  BOOST_CHECK_EQUAL (std::strcmp (temp1.data(), temp.data()), 0);
+
+
+  img.setStream (123);
+  BOOST_CHECK_EQUAL (img.getStream(), 123);
+
+  BOOST_CHECK_EQUAL (img.getSignature(), ISMRMRD_SIGNATURE);
+  BOOST_CHECK_EQUAL (img.getVersion(), 2); //TODO: Use ISMRMRD_VERSION_MAJOR?
+  BOOST_CHECK_EQUAL (img.getEntityType(), ISMRMRD_IMAGE);
+  BOOST_CHECK_EQUAL (img.getStorageType(), get_storage_type<T>());
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(image_resize,T, test_types)
+BOOST_AUTO_TEST_CASE_TEMPLATE (image_resize, T, test_types)
 {
-    Image<T> img;
-    check_header(img.getHead());
-    BOOST_CHECK_EQUAL(img.getData().size(), 0);
+  Image<T> img;
+  check_header (img.getHead());
+  BOOST_CHECK_EQUAL (img.getData().size(), 0);
 
-    img.resize(72, 72, 24, 0);
-    BOOST_CHECK_EQUAL(img.getMatrixSizeX(), 72);
-    BOOST_CHECK_EQUAL(img.getMatrixSizeY(), 72);
-    BOOST_CHECK_EQUAL(img.getMatrixSizeZ(), 24);
-    BOOST_CHECK_EQUAL(img.getData().size(), 72*72*24);
+  img.resize (72, 72, 24, 0);
+  BOOST_CHECK_EQUAL (img.getMatrixSizeX(), 72);
+  BOOST_CHECK_EQUAL (img.getMatrixSizeY(), 72);
+  BOOST_CHECK_EQUAL (img.getMatrixSizeZ(), 24);
+  BOOST_CHECK_EQUAL (img.getData().size(), 72 * 72 * 24);
 
-    std::vector<T> zeros(72*72*24, 0);
-    BOOST_CHECK_EQUAL_COLLECTIONS(zeros.begin(), zeros.end(),
-            img.getData().begin(), img.getData().end());
+  std::vector<T> zeros (72 * 72 * 24, 0);
+  BOOST_CHECK_EQUAL_COLLECTIONS (zeros.begin(), zeros.end(),
+                                 img.getData().begin(), img.getData().end());
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(image_serialize, T, test_types)
+BOOST_AUTO_TEST_CASE_TEMPLATE (image_serialize, T, test_types)
 {
-    Image<T> im(256,256,10,12);
+  Image<T> im (256, 256, 10, 12);
 
-    std::vector<unsigned char> buffer = im.serialize();
+  std::vector<unsigned char> buffer = im.serialize();
 
-    Image<T> im2;
-    im2.deserialize(buffer);
+  Image<T> im2;
+  im2.deserialize (buffer);
     
-    BOOST_CHECK_EQUAL_COLLECTIONS(im.getData().begin(), im.getData().end(),
-                                  im2.getData().begin(), im2.getData().end());
+  BOOST_CHECK_EQUAL_COLLECTIONS (im.getData().begin(), im.getData().end(),
+                                 im2.getData().begin(), im2.getData().end());
     
-    BOOST_CHECK(im.getAttributeString() == im2.getAttributeString());
-    
-    BOOST_CHECK(im.getHead() == im2.getHead());
+  BOOST_CHECK (im.getAttributeString() == im2.getAttributeString());
+  
+  BOOST_CHECK (im.getHead() == im2.getHead());
 }
 
-static void check_header(const ImageHeader& chead)
+static void check_header (const ImageHeader& chead)
 {
-    BOOST_CHECK_EQUAL(chead.ent_head.signature, ISMRMRD_SIGNATURE);
-    BOOST_CHECK_EQUAL(chead.matrix_size[0], 0);
-    BOOST_CHECK_EQUAL(chead.matrix_size[1], 1);
-    BOOST_CHECK_EQUAL(chead.matrix_size[2], 1);
-    BOOST_CHECK_EQUAL(chead.channels, 1);
+  BOOST_CHECK_EQUAL (chead.ent_head.stream, 0);
+  BOOST_CHECK_EQUAL (chead.ent_head.signature, ISMRMRD_SIGNATURE);
+  BOOST_CHECK_EQUAL (chead.ent_head.entity_type, ISMRMRD_IMAGE);
 
-    //BOOST_CHECK_EQUAL(chead.storage_type, 0);
-    BOOST_CHECK_EQUAL(chead.flags, 0);
-    for (int idx = 0; idx < 3; idx++) {
-        BOOST_CHECK_EQUAL(chead.field_of_view[idx], 0);
-    }
-    for (int idx = 0; idx < ISMRMRD_POSITION_LENGTH; idx++) {
-        BOOST_CHECK_EQUAL(chead.position[idx], 0);
-    }
-    for (int idx = 0; idx < ISMRMRD_DIRECTION_LENGTH; idx++) {
-        BOOST_CHECK_EQUAL(chead.read_dir[idx], 0);
-    }
-    for (int idx = 0; idx < ISMRMRD_DIRECTION_LENGTH; idx++) {
-        BOOST_CHECK_EQUAL(chead.phase_dir[idx], 0);
-    }
-    for (int idx = 0; idx < ISMRMRD_DIRECTION_LENGTH; idx++) {
-        BOOST_CHECK_EQUAL(chead.slice_dir[idx], 0);
-    }
-    for (int idx = 0; idx < ISMRMRD_POSITION_LENGTH; idx++) {
-        BOOST_CHECK_EQUAL(chead.patient_table_position[idx], 0);
-    }
-    BOOST_CHECK_EQUAL(chead.average, 0);
-    BOOST_CHECK_EQUAL(chead.slice, 0);
-    BOOST_CHECK_EQUAL(chead.contrast, 0);
-    BOOST_CHECK_EQUAL(chead.phase, 0);
-    BOOST_CHECK_EQUAL(chead.repetition, 0);
-    BOOST_CHECK_EQUAL(chead.set, 0);
-    for (int idx = 0; idx < ISMRMRD_PHYS_STAMPS; idx++) {
-        BOOST_CHECK_EQUAL(chead.physiology_time_stamp[idx], 0);
-    }
-    BOOST_CHECK_EQUAL(chead.image_type, 0);
-    BOOST_CHECK_EQUAL(chead.image_index, 0);
-    BOOST_CHECK_EQUAL(chead.image_series_index, 0);
+  BOOST_CHECK_EQUAL (chead.time_stamp, 0);
+  BOOST_CHECK_EQUAL (chead.flags, 0);
 
-    for (int idx = 0; idx < ISMRMRD_USER_INTS; idx++) {
-        BOOST_CHECK_EQUAL(chead.user_int[idx], 0);
-    }
-    for (int idx = 0; idx < ISMRMRD_USER_FLOATS; idx++) {
-        BOOST_CHECK_EQUAL(chead.user_float[idx], 0);
-    }
-    BOOST_CHECK_EQUAL(chead.attribute_string_len, 0);
+  BOOST_CHECK_EQUAL (chead.matrix_size[0], 0);
+  BOOST_CHECK_EQUAL (chead.matrix_size[1], 1);
+  BOOST_CHECK_EQUAL (chead.matrix_size[2], 1);
+
+  for (int idx = 0; idx < 3; idx++)
+  {
+    BOOST_CHECK_EQUAL (chead.field_of_view[idx], 0);
+  }
+
+  BOOST_CHECK_EQUAL (chead.channels, 1);
+
+  for (int idx = 0; idx < ISMRMRD_POSITION_LENGTH; idx++)
+  {
+    BOOST_CHECK_EQUAL (chead.position[idx], 0);
+  }
+
+  for (int idx = 0; idx < ISMRMRD_DIRECTION_LENGTH; idx++)
+  {
+    BOOST_CHECK_EQUAL (chead.read_dir[idx], 0);
+  }
+
+  for (int idx = 0; idx < ISMRMRD_DIRECTION_LENGTH; idx++)
+  {
+    BOOST_CHECK_EQUAL (chead.phase_dir[idx], 0);
+  }
+
+  for (int idx = 0; idx < ISMRMRD_DIRECTION_LENGTH; idx++)
+  {
+    BOOST_CHECK_EQUAL (chead.slice_dir[idx], 0);
+  }
+
+  for (int idx = 0; idx < ISMRMRD_POSITION_LENGTH; idx++)
+  {
+    BOOST_CHECK_EQUAL (chead.patient_table_position[idx], 0);
+  }
+
+  BOOST_CHECK_EQUAL (chead.average, 0);
+  BOOST_CHECK_EQUAL (chead.slice, 0);
+  BOOST_CHECK_EQUAL (chead.contrast, 0);
+  BOOST_CHECK_EQUAL (chead.phase, 0);
+  BOOST_CHECK_EQUAL (chead.repetition, 0);
+  BOOST_CHECK_EQUAL (chead.set, 0);
+
+  for (int idx = 0; idx < ISMRMRD_PHYS_STAMPS; idx++)
+  {
+    BOOST_CHECK_EQUAL (chead.physiology_time_stamp[idx], 0);
+  }
+
+  BOOST_CHECK_EQUAL (chead.image_type, 0);
+  BOOST_CHECK_EQUAL (chead.image_index, 0);
+  BOOST_CHECK_EQUAL (chead.image_series_index, 0);
+
+  for (int idx = 0; idx < ISMRMRD_USER_INTS; idx++)
+  {
+    BOOST_CHECK_EQUAL (chead.user_int[idx], 0);
+  }
+
+  for (int idx = 0; idx < ISMRMRD_USER_FLOATS; idx++)
+  {
+    BOOST_CHECK_EQUAL (chead.user_float[idx], 0);
+  }
+
+  BOOST_CHECK_EQUAL (chead.attribute_string_len, 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_text.cpp
+++ b/tests/test_text.cpp
@@ -1,0 +1,213 @@
+#include "ismrmrd/ismrmrd.h"
+#include "ismrmrd/version.h"
+#include <boost/test/unit_test.hpp>
+
+using namespace ISMRMRD;
+
+const std::string xml_header("\
+<?xml version=\"1.0\"?>\n\
+<ismrmrdHeader xmlns=\"http://www.ismrm.org/ISMRMRD\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xsi:schemaLocation=\"http://www.ismrm.org/ISMRMRD ismrmrd.xsd\">\n\
+ <version>4</version>\n\
+ <subjectInformation>\n\
+  <patientName>phantom</patientName>\n\
+  <patientWeight_kg>72.500000</patientWeight_kg>\n\
+ </subjectInformation>\n\
+ <studyInformation>\n\
+  <studyDate>2001-01-01</studyDate>\n\
+  <studyTime>00:01:02</studyTime>\n\
+  <studyDescription>Image Synthesis</studyDescription>\n\
+ </studyInformation>\n\
+ <measurementInformation>\n\
+  <measurementID>ABC123</measurementID>\n\
+  <seriesDate>2001-01-01</seriesDate>\n\
+  <seriesTime>01:02:03</seriesTime>\n\
+  <patientPosition>HFS</patientPosition>\n\
+  <protocolName>ISMRM Synthetic Imaging Protocol</protocolName>\n\
+  <measurementDependency>\n\
+   <dependencyType>calibration</dependencyType>\n\
+   <measurementID>BCD234</measurementID>\n\
+  </measurementDependency>\n\
+  <measurementDependency>\n\
+   <dependencyType>noise</dependencyType>\n\
+   <measurementID>CDE345</measurementID>\n\
+  </measurementDependency>\n\
+ </measurementInformation>\n\
+ <acquisitionSystemInformation>\n\
+  <receiverChannels>8</receiverChannels>\n\
+  <coilLabel>\n\
+   <coilNumber>0</coilNumber>\n\
+   <coilName>16Ch_Body_A</coilName>\n\
+  </coilLabel>\n\
+  <coilLabel>\n\
+   <coilNumber>1</coilNumber>\n\
+   <coilName>16Ch_Body_B</coilName>\n\
+  </coilLabel>\n\
+  <institutionName>ISMRM Synthetic Imaging Lab</institutionName>\n\
+ </acquisitionSystemInformation>\n\
+ <experimentalConditions>\n\
+  <H1resonanceFrequency_Hz>63500000</H1resonanceFrequency_Hz>\n\
+ </experimentalConditions>\n\
+ <encoding>\n\
+  <encodedSpace>\n\
+   <matrixSize>\n\
+    <x>512</x>\n\
+    <y>256</y>\n\
+    <z>1</z>\n\
+   </matrixSize>\n\
+   <fieldOfView_mm>\n\
+    <x>600.000000</x>\n\
+    <y>300.000000</y>\n\
+    <z>6.000000</z>\n\
+   </fieldOfView_mm>\n\
+  </encodedSpace>\n\
+  <reconSpace>\n\
+   <matrixSize>\n\
+    <x>256</x>\n\
+    <y>256</y>\n\
+    <z>1</z>\n\
+   </matrixSize>\n\
+   <fieldOfView_mm>\n\
+    <x>300.000000</x>\n\
+    <y>300.000000</y>\n\
+    <z>6.000000</z>\n\
+   </fieldOfView_mm>\n\
+  </reconSpace>\n\
+  <encodingLimits>\n\
+   <kspace_encoding_step_1>\n\
+    <minimum>0</minimum>\n\
+    <maximum>255</maximum>\n\
+    <center>128</center>\n\
+   </kspace_encoding_step_1>\n\
+   <repetition>\n\
+    <minimum>0</minimum>\n\
+    <maximum>3</maximum>\n\
+    <center>0</center>\n\
+   </repetition>\n\
+  </encodingLimits>\n\
+  <trajectory>cartesian</trajectory>\n\
+  <parallelImaging>\n\
+   <accelerationFactor>\n\
+    <kspace_encoding_step_1>2</kspace_encoding_step_1>\n\
+    <kspace_encoding_step_2>1</kspace_encoding_step_2>\n\
+   </accelerationFactor>\n\
+   <calibrationMode>interleaved</calibrationMode>\n\
+  </parallelImaging>\n\
+ </encoding>\n\
+ <streams>\n\
+  <stream>\n\
+   <label>k-space</label>\n\
+   <entityType>MRAcquisition</entityType>\n\
+   <number>0</number>\n\
+   <storageType>cxfloat</storageType>\n\
+  </stream>\n\
+  <stream>\n\
+   <label>ECG</label>\n\
+   <entityType>MRAcquisition</entityType>\n\
+   <number>2</number>\n\
+   <storageType>float</storageType>\n\
+  </stream>\n\
+ </streams>\n\
+ <sequenceParameters>\n\
+  <TR>5.860000</TR>\n\
+  <TE>2.960000</TE>\n\
+  <TE>4.240000</TE>\n\
+ </sequenceParameters>\n\
+ <userParameters>\n\
+  <userParameterLong>\n\
+   <name>age</name>\n\
+   <value>42</value>\n\
+  </userParameterLong>\n\
+  <userParameterDouble>\n\
+   <name>center frequency</name>\n\
+   <value>63500000.000000</value>\n\
+  </userParameterDouble>\n\
+  <userParameterString>\n\
+   <name>tag</name>\n\
+   <value>synthetic</value>\n\
+  </userParameterString>\n\
+  <userParameterString>\n\
+   <name>author</name>\n\
+   <value>ISMRMRD Developers</value>\n\
+  </userParameterString>\n\
+ </userParameters>\n\
+</ismrmrdHeader>\n\
+");
+
+BOOST_AUTO_TEST_SUITE (TextEntity)
+
+BOOST_AUTO_TEST_CASE (text_create)
+{
+  IsmrmrdText txt;
+
+  BOOST_CHECK_EQUAL (txt.getEntityType(), ISMRMRD_TEXT);
+  BOOST_CHECK_EQUAL (txt.getStorageType(), ISMRMRD_CHAR);
+  BOOST_CHECK_EQUAL (txt.getTextType(), ISMRMRD_TEXT_ERROR);
+  BOOST_CHECK_EQUAL (txt.getSize(), 0);
+
+  txt.setText (xml_header, ISMRMRD_XML_HEADER_TEXT);
+  BOOST_CHECK_EQUAL (txt.getSize(), xml_header.size());
+
+  IsmrmrdText txt1 (xml_header, ISMRMRD_XML_HEADER_TEXT);
+
+  BOOST_CHECK_EQUAL (txt1.getEntityType(), ISMRMRD_TEXT);
+  BOOST_CHECK_EQUAL (txt1.getStorageType(), ISMRMRD_CHAR);
+  BOOST_CHECK_EQUAL (txt1.getTextType(), ISMRMRD_XML_HEADER_TEXT);
+  BOOST_CHECK_EQUAL (txt1.getSize(), xml_header.size());
+  BOOST_CHECK_EQUAL (txt1.getTextString(), xml_header);
+
+  std::vector<unsigned char> head_vec (xml_header.begin(), xml_header.end());
+
+  IsmrmrdText txt2 (head_vec, ISMRMRD_XML_HEADER_TEXT);
+
+  BOOST_CHECK_EQUAL (txt2.getEntityType(), ISMRMRD_TEXT);
+  BOOST_CHECK_EQUAL (txt2.getStorageType(), ISMRMRD_CHAR);
+  BOOST_CHECK_EQUAL (txt2.getTextType(), ISMRMRD_XML_HEADER_TEXT);
+  BOOST_CHECK_EQUAL (txt2.getSize(), xml_header.size());
+  BOOST_CHECK_EQUAL (txt2.getSize(), head_vec.size());
+  BOOST_CHECK_EQUAL (txt2.getTextString(), xml_header);
+  BOOST_CHECK (txt2.getTextVector() == head_vec);
+}
+
+BOOST_AUTO_TEST_CASE (text_check_types)
+{
+  std::vector<unsigned char> head_vec (xml_header.begin(), xml_header.end());
+
+  IsmrmrdText txt1 (xml_header, ISMRMRD_XML_HEADER_TEXT);
+  IsmrmrdText txt2 (head_vec, ISMRMRD_XML_HEADER_TEXT);
+
+  BOOST_CHECK (txt1.getTextString() == txt2.getTextString());
+  BOOST_CHECK (txt1.getTextVector() == txt2.getTextVector());
+}
+
+BOOST_AUTO_TEST_CASE (text_serialize)
+{
+  IsmrmrdText txt1 (xml_header, ISMRMRD_XML_HEADER_TEXT);
+  std::vector<unsigned char> temp (txt1.serialize());
+
+  IsmrmrdText txt2;
+  txt2.deserialize (temp);
+  BOOST_CHECK_EQUAL (txt2.getEntityType(), ISMRMRD_TEXT);
+  BOOST_CHECK_EQUAL (txt2.getStorageType(), ISMRMRD_CHAR);
+  BOOST_CHECK_EQUAL (txt2.getTextType(), ISMRMRD_XML_HEADER_TEXT);
+  BOOST_CHECK_EQUAL (txt2.getSize(), xml_header.size());
+  BOOST_CHECK_EQUAL (txt2.getTextString(), xml_header);
+}
+
+BOOST_AUTO_TEST_CASE (waveform_getters_setters)
+{
+  IsmrmrdText txt1;
+
+  txt1.setText (xml_header, ISMRMRD_XML_HEADER_TEXT);
+  BOOST_CHECK_EQUAL (txt1.getTextType(), ISMRMRD_XML_HEADER_TEXT);
+  BOOST_CHECK_EQUAL (txt1.getSize(), xml_header.size());
+  BOOST_CHECK_EQUAL (txt1.getTextString(), xml_header);
+
+  std::vector<unsigned char> head_vec (xml_header.begin(), xml_header.end());
+  IsmrmrdText txt2;
+  txt2.setText (head_vec, ISMRMRD_XML_HEADER_TEXT);
+  BOOST_CHECK_EQUAL (txt2.getTextType(), ISMRMRD_XML_HEADER_TEXT);
+  BOOST_CHECK_EQUAL (txt2.getSize(), head_vec.size());
+  BOOST_CHECK (txt2.getTextVector() == head_vec);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_waveform.cpp
+++ b/tests/test_waveform.cpp
@@ -1,0 +1,154 @@
+#include "ismrmrd/ismrmrd.h"
+#include "ismrmrd/version.h"
+#include <boost/test/unit_test.hpp>
+
+using namespace ISMRMRD;
+
+BOOST_AUTO_TEST_SUITE (Waveforms)
+
+static void check_header (const WaveformHeader& head);
+
+BOOST_AUTO_TEST_CASE (waveform_create)
+{
+  Waveform wvf;
+  WaveformHeader head = wvf.getHead();
+  EntityHeader   ehdr = head.ent_head;
+
+  size_t ehdr_size = sizeof(uint32_t) * 4;
+  BOOST_CHECK_EQUAL (sizeof(ehdr), ehdr_size);
+
+  size_t expected_size = sizeof(ehdr) +
+                         sizeof(uint64_t) * 2 +
+                         sizeof(uint32_t) * 2 + 
+                         sizeof(int32_t) * ISMRMRD_USER_INTS + 
+                         sizeof(float) * ISMRMRD_USER_FLOATS;
+
+  BOOST_CHECK_EQUAL (sizeof(head), expected_size);
+
+  // Check that header is initialized properly
+  check_header (head);
+}
+
+BOOST_AUTO_TEST_CASE (waveform_copy)
+{
+  Waveform wvf1;
+  check_header (wvf1.getHead());
+  Waveform wvf2 (wvf1);
+  check_header (wvf2.getHead());
+
+  BOOST_CHECK (wvf1.getHead() == wvf2.getHead());
+
+  Waveform wvf3;
+  wvf3.setHead (wvf1.getHead());
+  BOOST_CHECK (wvf3.getHead() == wvf1.getHead());
+  BOOST_CHECK_EQUAL (wvf3.getNumberOfSamples(), wvf1.getNumberOfSamples());
+}
+
+BOOST_AUTO_TEST_CASE (waveform_getters_setters)
+{
+  Waveform wvf;
+
+  wvf.setBeginTimeStamp (3456789012);
+  BOOST_CHECK_EQUAL (wvf.getBeginTimeStamp(), 3456789012);
+
+  wvf.setEndTimeStamp (2134567890);
+  BOOST_CHECK_EQUAL (wvf.getEndTimeStamp(), 2134567890);
+
+  wvf.resize (4096);
+  BOOST_CHECK_EQUAL (wvf.getNumberOfSamples(), 4096);
+
+  wvf.setDwellTime_ns (1321);
+  BOOST_CHECK_EQUAL (wvf.getDwellTime_ns(), 1321);
+
+  for (int ii = 0; ii < ISMRMRD_USER_INTS; ii++)
+  {
+    wvf.setUserInt (ii, ii + 99);
+    BOOST_CHECK_EQUAL (wvf.getUserInt (ii), ii + 99);
+  }
+
+  for (int ii = 0; ii < ISMRMRD_USER_FLOATS; ii++)
+  {
+    wvf.setUserFloat (ii, ii + 147.5);
+    BOOST_CHECK_CLOSE (wvf.getUserFloat (ii), ii + 147.5, 0.01);
+  }
+
+  wvf.resize (256);
+  std::vector<double> data (256);
+  for (int ii = 0; ii < 256; ii++)
+  {
+    data[ii] = ii * 1.234;
+  }
+  wvf.setData (data);
+  std::vector<double> data1 (wvf.getData());
+  for (int ii = 0; ii < 256; ii++)
+  {
+    BOOST_CHECK_CLOSE (data[ii], data1[ii], 0.01);
+  }
+
+  for (uint32_t ii = 0; ii < 256; ii++)
+  {
+    BOOST_CHECK_CLOSE (wvf.at (ii), data1[ii], 0.01);
+  }
+
+  wvf.setStream (432);
+  BOOST_CHECK_EQUAL (wvf.getStream(), 432);
+
+  BOOST_CHECK_EQUAL (wvf.getSignature(), ISMRMRD_SIGNATURE);
+  BOOST_CHECK_EQUAL (wvf.getVersion(), ISMRMRD_VERSION_MAJOR);
+  BOOST_CHECK_EQUAL (wvf.getEntityType(), ISMRMRD_WAVEFORM);
+  BOOST_CHECK_EQUAL (wvf.getStorageType(), ISMRMRD_DOUBLE);
+}
+
+BOOST_AUTO_TEST_CASE (waveform_resize)
+{
+  Waveform wvf;
+
+  check_header (wvf.getHead());
+  BOOST_CHECK_EQUAL (wvf.getData().size(), 0);
+  BOOST_CHECK_EQUAL (wvf.getNumberOfSamples(), 0);
+
+  wvf.resize (9192);
+  std::vector<double> temp (9192, 0);
+
+  BOOST_CHECK_EQUAL_COLLECTIONS (temp.begin(), temp.end(),
+                                 wvf.getData().begin(), wvf.getData().end());
+}
+
+BOOST_AUTO_TEST_CASE (serialize)
+{
+  Waveform wvf (2048);
+  std::vector <unsigned char> buf = wvf.serialize();
+
+  Waveform wvf1;
+  wvf1.deserialize (buf);
+
+  BOOST_CHECK (wvf.getHead() == wvf1.getHead());
+  BOOST_CHECK_EQUAL_COLLECTIONS (wvf.getData().begin(), wvf.getData().end(),
+                                 wvf1.getData().begin(), wvf1.getData().end());
+}
+
+static void check_header (const WaveformHeader& head)
+{
+  BOOST_CHECK_EQUAL (head.begin_time_stamp, 0);
+  BOOST_CHECK_EQUAL (head.end_time_stamp, 0);
+  BOOST_CHECK_EQUAL (head.number_of_samples, 0);
+  BOOST_CHECK_EQUAL (head.dwell_time_ns, 0);
+
+  for (uint32_t ii = 0; ii < ISMRMRD_USER_INTS; ii++)
+  {
+    BOOST_CHECK_EQUAL (head.user_int[ii], 0);
+  }
+
+  for (uint32_t ii = 0; ii < ISMRMRD_USER_FLOATS; ii++)
+  {
+    BOOST_CHECK_CLOSE (head.user_float[ii], 0, 0.01);
+  }
+
+  BOOST_CHECK_EQUAL (head.ent_head.signature, ISMRMRD_SIGNATURE);
+  BOOST_CHECK_EQUAL (head.ent_head.stream, 0);
+  BOOST_CHECK_EQUAL (head.ent_head.entity_type, ISMRMRD_WAVEFORM);
+  BOOST_CHECK_EQUAL (head.ent_head.storage_type, ISMRMRD_DOUBLE);
+
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_waveform.cpp
+++ b/tests/test_waveform.cpp
@@ -12,13 +12,8 @@ BOOST_AUTO_TEST_CASE (waveform_create)
 {
   Waveform wvf;
   WaveformHeader head = wvf.getHead();
-  EntityHeader   ehdr = head.ent_head;
 
-  size_t ehdr_size = sizeof(uint32_t) * 4;
-  BOOST_CHECK_EQUAL (sizeof(ehdr), ehdr_size);
-
-  size_t expected_size = sizeof(ehdr) +
-                         sizeof(uint64_t) * 2 +
+  size_t expected_size = sizeof(uint64_t) * 2 +
                          sizeof(uint32_t) * 2 + 
                          sizeof(int32_t) * ISMRMRD_USER_INTS + 
                          sizeof(float) * ISMRMRD_USER_FLOATS;
@@ -90,11 +85,6 @@ BOOST_AUTO_TEST_CASE (waveform_getters_setters)
     BOOST_CHECK_CLOSE (wvf.at (ii), data1[ii], 0.01);
   }
 
-  wvf.setStream (432);
-  BOOST_CHECK_EQUAL (wvf.getStream(), 432);
-
-  BOOST_CHECK_EQUAL (wvf.getSignature(), ISMRMRD_SIGNATURE);
-  BOOST_CHECK_EQUAL (wvf.getVersion(), ISMRMRD_VERSION_MAJOR);
   BOOST_CHECK_EQUAL (wvf.getEntityType(), ISMRMRD_WAVEFORM);
   BOOST_CHECK_EQUAL (wvf.getStorageType(), ISMRMRD_DOUBLE);
 }
@@ -143,12 +133,6 @@ static void check_header (const WaveformHeader& head)
   {
     BOOST_CHECK_CLOSE (head.user_float[ii], 0, 0.01);
   }
-
-  BOOST_CHECK_EQUAL (head.ent_head.signature, ISMRMRD_SIGNATURE);
-  BOOST_CHECK_EQUAL (head.ent_head.stream, 0);
-  BOOST_CHECK_EQUAL (head.ent_head.entity_type, ISMRMRD_WAVEFORM);
-  BOOST_CHECK_EQUAL (head.ent_head.storage_type, ISMRMRD_DOUBLE);
-
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_xml.cpp
+++ b/tests/test_xml.cpp
@@ -10,12 +10,6 @@ using namespace ISMRMRD;
 const std::string XML_HEADER("\
 <?xml version=\"1.0\"?>\n\
 <ismrmrdHeader xmlns=\"http://www.ismrm.org/ISMRMRD\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xsi:schemaLocation=\"http://www.ismrm.org/ISMRMRD ismrmrd.xsd\">\n\
-	<EntityHeader>\n\
-		<stream>1</stream>\n\
-		<signature>367583234</signature>\n\
-		<entity_type>6</entity_type>\n\
-		<storage_type>0</storage_type>\n\
-	</EntityHeader>\n\
 	<version>4</version>\n\
 	<subjectInformation>\n\
 		<patientName>phantom</patientName>\n\
@@ -153,7 +147,7 @@ IsmrmrdHeader build_model_header (void)
 
   IsmrmrdHeader head;
 
-  //head.version = ISMRMRD_XMLHDR_VERSION;
+  head.version = ISMRMRD_XMLHDR_VERSION;
   head.experimentalConditions.H1resonanceFrequency_Hz = 63500000; // ~1.5T
 
   SubjectInformation subj;
@@ -269,41 +263,18 @@ BOOST_AUTO_TEST_CASE (test_serialize_header)
 {
   IsmrmrdHeader head = build_model_header();
 
-  //std::stringstream str;
-  //ISMRMRD::serialize(head, str);
-  //std::string xml_header = str.str();
-
-  std::vector<unsigned char> buffer =  head.serialize ();
-  std::string xml_header (buffer.begin(), buffer.end());
+  std::stringstream str;
+  ISMRMRD::serialize(head, str);
+  std::string xml_header = str.str();
 
   BOOST_CHECK_EQUAL(xml_header, XML_HEADER);
 }
 
 BOOST_AUTO_TEST_CASE(test_deserialize_header)
 {
-  //IsmrmrdHeader head;
-  //ISMRMRD::deserialize(XML_HEADER.c_str(), head);
-
   IsmrmrdHeader head;
-  std::vector<unsigned char> buffer (XML_HEADER.begin(), XML_HEADER.end());
-  head.deserialize (buffer);
+  ISMRMRD::deserialize(XML_HEADER.c_str(), head);
   IsmrmrdHeader model = build_model_header();
-
-  BOOST_CHECK_EQUAL (head.ent_head.stream, model.ent_head.stream);
-  BOOST_CHECK_EQUAL (head.ent_head.signature, model.ent_head.signature);
-  BOOST_CHECK_EQUAL (head.ent_head.entity_type, model.ent_head.entity_type);
-  BOOST_CHECK_EQUAL (head.ent_head.storage_type, model.ent_head.storage_type);
-
-  BOOST_CHECK_EQUAL (head.getStream(), ISMRMRD_HEADER_STREAM);
-  BOOST_CHECK_EQUAL (model.getStream(), ISMRMRD_HEADER_STREAM);
-  BOOST_CHECK_EQUAL (head.getSignature(), ISMRMRD_SIGNATURE);
-  BOOST_CHECK_EQUAL (model.getSignature(), ISMRMRD_SIGNATURE);
-  BOOST_CHECK_EQUAL (head.getVersion(), ISMRMRD_VERSION_MAJOR);
-  BOOST_CHECK_EQUAL (model.getVersion(), ISMRMRD_VERSION_MAJOR);
-  BOOST_CHECK_EQUAL (head.getEntityType(), ISMRMRD_XML_HEADER);
-  BOOST_CHECK_EQUAL (model.getEntityType(), ISMRMRD_XML_HEADER);
-  BOOST_CHECK_EQUAL (head.getStorageType(), ISMRMRD_STORAGE_NONE);
-  BOOST_CHECK_EQUAL (model.getStorageType(), ISMRMRD_STORAGE_NONE);
 
   BOOST_CHECK_EQUAL(head.version, model.version);
 

--- a/tests/test_xml.cpp
+++ b/tests/test_xml.cpp
@@ -10,6 +10,12 @@ using namespace ISMRMRD;
 const std::string XML_HEADER("\
 <?xml version=\"1.0\"?>\n\
 <ismrmrdHeader xmlns=\"http://www.ismrm.org/ISMRMRD\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xsi:schemaLocation=\"http://www.ismrm.org/ISMRMRD ismrmrd.xsd\">\n\
+	<EntityHeader>\n\
+		<stream>1</stream>\n\
+		<signature>367583234</signature>\n\
+		<entity_type>6</entity_type>\n\
+		<storage_type>0</storage_type>\n\
+	</EntityHeader>\n\
 	<version>4</version>\n\
 	<subjectInformation>\n\
 		<patientName>phantom</patientName>\n\
@@ -136,219 +142,242 @@ const std::string XML_HEADER("\
 </ismrmrdHeader>\n\
 ");
 
-IsmrmrdHeader build_model_header(void)
+IsmrmrdHeader build_model_header (void)
 {
-    unsigned int matrix_size = 256;
-    unsigned int ros = 2; // readout oversampling
-    unsigned int repetitions = 2;
-    unsigned int readout = matrix_size * ros;
-    unsigned int ncoils = 8;
-    unsigned int acc_factor = 2; // acceleration factor
+  unsigned int matrix_size = 256;
+  unsigned int ros = 2; // readout oversampling
+  unsigned int repetitions = 2;
+  unsigned int readout = matrix_size * ros;
+  unsigned int ncoils = 8;
+  unsigned int acc_factor = 2; // acceleration factor
 
-    IsmrmrdHeader head;
+  IsmrmrdHeader head;
 
-    head.version = ISMRMRD_XMLHDR_VERSION;
-    head.experimentalConditions.H1resonanceFrequency_Hz = 63500000; // ~1.5T
+  //head.version = ISMRMRD_XMLHDR_VERSION;
+  head.experimentalConditions.H1resonanceFrequency_Hz = 63500000; // ~1.5T
 
-    SubjectInformation subj;
-    subj.patientName = "phantom";
-    subj.patientWeight_kg = 72.5;
-    head.subjectInformation = subj;
+  SubjectInformation subj;
+  subj.patientName = "phantom";
+  subj.patientWeight_kg = 72.5;
+  head.subjectInformation = subj;
 
-    StudyInformation study;
-    study.studyDate = "2001-01-01";
-    study.studyTime = "00:01:02";
-    study.studyDescription = "Image Synthesis";
-    head.studyInformation = study;
+  StudyInformation study;
+  study.studyDate = "2001-01-01";
+  study.studyTime = "00:01:02";
+  study.studyDescription = "Image Synthesis";
+  head.studyInformation = study;
 
-    AcquisitionSystemInformation sys;
-    sys.institutionName = "ISMRM Synthetic Imaging Lab";
-    sys.receiverChannels = ncoils;
-    std::vector<CoilLabel> coil_labels(2);
-    coil_labels[0].coilNumber = 0;
-    coil_labels[0].coilName = "16Ch_Body_A";
-    coil_labels[1].coilNumber = 1;
-    coil_labels[1].coilName = "16Ch_Body_B";
-    sys.coilLabel = coil_labels;
-    head.acquisitionSystemInformation = sys;
+  AcquisitionSystemInformation sys;
+  sys.institutionName = "ISMRM Synthetic Imaging Lab";
+  sys.receiverChannels = ncoils;
+  std::vector<CoilLabel> coil_labels(2);
+  coil_labels[0].coilNumber = 0;
+  coil_labels[0].coilName = "16Ch_Body_A";
+  coil_labels[1].coilNumber = 1;
+  coil_labels[1].coilName = "16Ch_Body_B";
+  sys.coilLabel = coil_labels;
+  head.acquisitionSystemInformation = sys;
 
-    MeasurementInformation meas;
-    meas.measurementID = "ABC123";
-    meas.seriesDate = "2001-01-01";
-    meas.seriesTime = "01:02:03";
-    meas.patientPosition = "HFS";
-    meas.protocolName = "ISMRM Synthetic Imaging Protocol";
-    std::vector<MeasurementDependency> deps(2);
-    deps[0].dependencyType = "calibration";
-    deps[0].measurementID = "BCD234";
-    deps[1].dependencyType = "noise";
-    deps[1].measurementID = "CDE345";
-    meas.measurementDependency = deps;
-    head.measurementInformation = meas;
+  MeasurementInformation meas;
+  meas.measurementID = "ABC123";
+  meas.seriesDate = "2001-01-01";
+  meas.seriesTime = "01:02:03";
+  meas.patientPosition = "HFS";
+  meas.protocolName = "ISMRM Synthetic Imaging Protocol";
+  std::vector<MeasurementDependency> deps(2);
+  deps[0].dependencyType = "calibration";
+  deps[0].measurementID = "BCD234";
+  deps[1].dependencyType = "noise";
+  deps[1].measurementID = "CDE345";
+  meas.measurementDependency = deps;
+  head.measurementInformation = meas;
 
-    Encoding e;
-    e.encodedSpace.matrixSize.x = readout;
-    e.encodedSpace.matrixSize.y = matrix_size;
-    e.encodedSpace.matrixSize.z = 1;
-    e.encodedSpace.fieldOfView_mm.x = 600;
-    e.encodedSpace.fieldOfView_mm.y = 300;
-    e.encodedSpace.fieldOfView_mm.z = 6;
-    e.reconSpace.matrixSize.x = readout / 2;
-    e.reconSpace.matrixSize.y = matrix_size;
-    e.reconSpace.matrixSize.z = 1;
-    e.reconSpace.fieldOfView_mm.x = 300;
-    e.reconSpace.fieldOfView_mm.y = 300;
-    e.reconSpace.fieldOfView_mm.z = 6;
-    e.trajectory = "cartesian";
-    e.encodingLimits.kspace_encoding_step_1 = Limit(0, matrix_size - 1, matrix_size / 2);
-    e.encodingLimits.repetition = Limit(0, repetitions * acc_factor - 1, 0);
+  Encoding e;
+  e.encodedSpace.matrixSize.x = readout;
+  e.encodedSpace.matrixSize.y = matrix_size;
+  e.encodedSpace.matrixSize.z = 1;
+  e.encodedSpace.fieldOfView_mm.x = 600;
+  e.encodedSpace.fieldOfView_mm.y = 300;
+  e.encodedSpace.fieldOfView_mm.z = 6;
+  e.reconSpace.matrixSize.x = readout / 2;
+  e.reconSpace.matrixSize.y = matrix_size;
+  e.reconSpace.matrixSize.z = 1;
+  e.reconSpace.fieldOfView_mm.x = 300;
+  e.reconSpace.fieldOfView_mm.y = 300;
+  e.reconSpace.fieldOfView_mm.z = 6;
+  e.trajectory = "cartesian";
+  e.encodingLimits.kspace_encoding_step_1 = Limit(0, matrix_size - 1, matrix_size / 2);
+  e.encodingLimits.repetition = Limit(0, repetitions * acc_factor - 1, 0);
 
-    ParallelImaging parallel;
-    parallel.accelerationFactor.kspace_encoding_step_1 = acc_factor;
-    parallel.accelerationFactor.kspace_encoding_step_2 = 1;
-    parallel.calibrationMode = "interleaved";
-    e.parallelImaging = parallel;
+  ParallelImaging parallel;
+  parallel.accelerationFactor.kspace_encoding_step_1 = acc_factor;
+  parallel.accelerationFactor.kspace_encoding_step_2 = 1;
+  parallel.calibrationMode = "interleaved";
+  e.parallelImaging = parallel;
 
-    head.encoding.push_back(e);
+  head.encoding.push_back(e);
 
-    Stream stream1;
-    stream1.label = "k-space";
-    stream1.storageType = ISMRMRD_CXFLOAT;
-    stream1.entityType = ISMRMRD_MRACQUISITION;
-    stream1.number = 0;
-    head.streams.push_back(stream1);
+  Stream stream1;
+  stream1.label = "k-space";
+  stream1.storageType = ISMRMRD_CXFLOAT;
+  stream1.entityType = ISMRMRD_MRACQUISITION;
+  stream1.number = 0;
+  head.streams.push_back(stream1);
 
-    Stream stream2;
-    stream2.label = "ECG";
-    stream2.storageType = ISMRMRD_FLOAT;
-    stream2.entityType = ISMRMRD_MRACQUISITION;
-    stream2.number = 2;
-    head.streams.push_back(stream2);
+  Stream stream2;
+  stream2.label = "ECG";
+  stream2.storageType = ISMRMRD_FLOAT;
+  stream2.entityType = ISMRMRD_MRACQUISITION;
+  stream2.number = 2;
+  head.streams.push_back(stream2);
 
-    SequenceParameters seq;
-    std::vector<float> TE, TR;
-    TR.push_back(5.86);
-    TE.push_back(2.96);
-    TE.push_back(4.24);
-    seq.TR = TR;
-    seq.TE = TE;
-    head.sequenceParameters = seq;
+  SequenceParameters seq;
+  std::vector<float> TE, TR;
+  TR.push_back(5.86);
+  TE.push_back(2.96);
+  TE.push_back(4.24);
+  seq.TR = TR;
+  seq.TE = TE;
+  head.sequenceParameters = seq;
 
-    UserParameters params;
-    UserParameterLong uplong;
-    uplong.name = "age";
-    uplong.value = 42;
+  UserParameters params;
+  UserParameterLong uplong;
+  uplong.name = "age";
+  uplong.value = 42;
 
-    UserParameterDouble updouble;
-    updouble.name = "center frequency";
-    updouble.value = 63500000.0;
+  UserParameterDouble updouble;
+  updouble.name = "center frequency";
+  updouble.value = 63500000.0;
 
-    std::vector<UserParameterString> upstrings(2);
-    upstrings[0].name = "tag";
-    upstrings[0].value = "synthetic";
-    upstrings[1].name = "author";
-    upstrings[1].value = "ISMRMRD Developers";
+  std::vector<UserParameterString> upstrings(2);
+  upstrings[0].name = "tag";
+  upstrings[0].value = "synthetic";
+  upstrings[1].name = "author";
+  upstrings[1].value = "ISMRMRD Developers";
 
-    params.userParameterLong.push_back(uplong);
-    params.userParameterDouble.push_back(updouble);
-    params.userParameterString = upstrings;
-    head.userParameters = params;
+  params.userParameterLong.push_back(uplong);
+  params.userParameterDouble.push_back(updouble);
+  params.userParameterString = upstrings;
+  head.userParameters = params;
 
-    return head;
+  return head;
 }
 
-BOOST_AUTO_TEST_SUITE(XMLTest)
+BOOST_AUTO_TEST_SUITE (XMLTest)
 
-BOOST_AUTO_TEST_CASE(test_serialize_header)
+BOOST_AUTO_TEST_CASE (test_serialize_header)
 {
-    IsmrmrdHeader head = build_model_header();
+  IsmrmrdHeader head = build_model_header();
 
-    std::stringstream str;
-    ISMRMRD::serialize(head, str);
-    std::string xml_header = str.str();
+  //std::stringstream str;
+  //ISMRMRD::serialize(head, str);
+  //std::string xml_header = str.str();
 
-    BOOST_CHECK_EQUAL(xml_header, XML_HEADER);
+  std::vector<unsigned char> buffer =  head.serialize ();
+  std::string xml_header (buffer.begin(), buffer.end());
+
+  BOOST_CHECK_EQUAL(xml_header, XML_HEADER);
 }
 
 BOOST_AUTO_TEST_CASE(test_deserialize_header)
 {
-    IsmrmrdHeader head;
-    ISMRMRD::deserialize(XML_HEADER.c_str(), head);
-    IsmrmrdHeader model = build_model_header();
+  //IsmrmrdHeader head;
+  //ISMRMRD::deserialize(XML_HEADER.c_str(), head);
 
-    BOOST_CHECK_EQUAL(head.version, model.version);
+  IsmrmrdHeader head;
+  std::vector<unsigned char> buffer (XML_HEADER.begin(), XML_HEADER.end());
+  head.deserialize (buffer);
+  IsmrmrdHeader model = build_model_header();
 
-    BOOST_CHECK_EQUAL(head.experimentalConditions.H1resonanceFrequency_Hz, model.experimentalConditions.H1resonanceFrequency_Hz);
+  BOOST_CHECK_EQUAL (head.ent_head.stream, model.ent_head.stream);
+  BOOST_CHECK_EQUAL (head.ent_head.signature, model.ent_head.signature);
+  BOOST_CHECK_EQUAL (head.ent_head.entity_type, model.ent_head.entity_type);
+  BOOST_CHECK_EQUAL (head.ent_head.storage_type, model.ent_head.storage_type);
 
-    BOOST_CHECK_EQUAL(head.subjectInformation.get().patientName, model.subjectInformation.get().patientName);
-    BOOST_CHECK_EQUAL(head.subjectInformation.get().patientWeight_kg, model.subjectInformation.get().patientWeight_kg);
+  BOOST_CHECK_EQUAL (head.getStream(), ISMRMRD_HEADER_STREAM);
+  BOOST_CHECK_EQUAL (model.getStream(), ISMRMRD_HEADER_STREAM);
+  BOOST_CHECK_EQUAL (head.getSignature(), ISMRMRD_SIGNATURE);
+  BOOST_CHECK_EQUAL (model.getSignature(), ISMRMRD_SIGNATURE);
+  BOOST_CHECK_EQUAL (head.getVersion(), ISMRMRD_VERSION_MAJOR);
+  BOOST_CHECK_EQUAL (model.getVersion(), ISMRMRD_VERSION_MAJOR);
+  BOOST_CHECK_EQUAL (head.getEntityType(), ISMRMRD_XML_HEADER);
+  BOOST_CHECK_EQUAL (model.getEntityType(), ISMRMRD_XML_HEADER);
+  BOOST_CHECK_EQUAL (head.getStorageType(), ISMRMRD_STORAGE_NONE);
+  BOOST_CHECK_EQUAL (model.getStorageType(), ISMRMRD_STORAGE_NONE);
 
-    BOOST_CHECK_EQUAL(head.studyInformation.get().studyDate, model.studyInformation.get().studyDate);
-    BOOST_CHECK_EQUAL(head.studyInformation.get().studyTime, model.studyInformation.get().studyTime);
-    BOOST_CHECK_EQUAL(head.studyInformation.get().studyDescription, model.studyInformation.get().studyDescription);
+  BOOST_CHECK_EQUAL(head.version, model.version);
 
-    BOOST_CHECK_EQUAL(head.acquisitionSystemInformation.get().institutionName, model.acquisitionSystemInformation.get().institutionName);
-    BOOST_CHECK_EQUAL(head.acquisitionSystemInformation.get().receiverChannels, model.acquisitionSystemInformation.get().receiverChannels);
-    BOOST_CHECK_EQUAL(head.acquisitionSystemInformation.get().coilLabel[0].coilNumber, model.acquisitionSystemInformation.get().coilLabel[0].coilNumber);
-    BOOST_CHECK_EQUAL(head.acquisitionSystemInformation.get().coilLabel[0].coilName, model.acquisitionSystemInformation.get().coilLabel[0].coilName);
-    BOOST_CHECK_EQUAL(head.acquisitionSystemInformation.get().coilLabel[1].coilNumber, model.acquisitionSystemInformation.get().coilLabel[1].coilNumber);
-    BOOST_CHECK_EQUAL(head.acquisitionSystemInformation.get().coilLabel[1].coilName, model.acquisitionSystemInformation.get().coilLabel[1].coilName);
+  BOOST_CHECK_EQUAL(head.experimentalConditions.H1resonanceFrequency_Hz, model.experimentalConditions.H1resonanceFrequency_Hz);
 
-    BOOST_CHECK_EQUAL(head.measurementInformation.get().measurementID, model.measurementInformation.get().measurementID);
-    BOOST_CHECK_EQUAL(head.measurementInformation.get().seriesDate, model.measurementInformation.get().seriesDate);
-    BOOST_CHECK_EQUAL(head.measurementInformation.get().seriesTime, model.measurementInformation.get().seriesTime);
-    BOOST_CHECK_EQUAL(head.measurementInformation.get().patientPosition, model.measurementInformation.get().patientPosition);
-    BOOST_CHECK_EQUAL(head.measurementInformation.get().protocolName, model.measurementInformation.get().protocolName);
-    BOOST_CHECK_EQUAL(head.measurementInformation.get().measurementDependency[0].dependencyType, model.measurementInformation.get().measurementDependency[0].dependencyType);
-    BOOST_CHECK_EQUAL(head.measurementInformation.get().measurementDependency[0].measurementID, model.measurementInformation.get().measurementDependency[0].measurementID);
-    BOOST_CHECK_EQUAL(head.measurementInformation.get().measurementDependency[1].dependencyType, model.measurementInformation.get().measurementDependency[1].dependencyType);
-    BOOST_CHECK_EQUAL(head.measurementInformation.get().measurementDependency[1].measurementID, model.measurementInformation.get().measurementDependency[1].measurementID);
+  BOOST_CHECK_EQUAL(head.subjectInformation.get().patientName, model.subjectInformation.get().patientName);
+  BOOST_CHECK_EQUAL(head.subjectInformation.get().patientWeight_kg, model.subjectInformation.get().patientWeight_kg);
 
-    BOOST_CHECK_EQUAL(head.encoding[0].encodedSpace.matrixSize.x, model.encoding[0].encodedSpace.matrixSize.x);
-    BOOST_CHECK_EQUAL(head.encoding[0].encodedSpace.matrixSize.y, model.encoding[0].encodedSpace.matrixSize.y);
-    BOOST_CHECK_EQUAL(head.encoding[0].encodedSpace.matrixSize.z, model.encoding[0].encodedSpace.matrixSize.z);
-    BOOST_CHECK_EQUAL(head.encoding[0].encodedSpace.fieldOfView_mm.x, model.encoding[0].encodedSpace.fieldOfView_mm.x);
-    BOOST_CHECK_EQUAL(head.encoding[0].encodedSpace.fieldOfView_mm.y, model.encoding[0].encodedSpace.fieldOfView_mm.y);
-    BOOST_CHECK_EQUAL(head.encoding[0].encodedSpace.fieldOfView_mm.z, model.encoding[0].encodedSpace.fieldOfView_mm.z);
-    BOOST_CHECK_EQUAL(head.encoding[0].reconSpace.matrixSize.x, model.encoding[0].reconSpace.matrixSize.x);
-    BOOST_CHECK_EQUAL(head.encoding[0].reconSpace.matrixSize.y, model.encoding[0].reconSpace.matrixSize.y);
-    BOOST_CHECK_EQUAL(head.encoding[0].reconSpace.matrixSize.z, model.encoding[0].reconSpace.matrixSize.z);
-    BOOST_CHECK_EQUAL(head.encoding[0].reconSpace.fieldOfView_mm.x, model.encoding[0].reconSpace.fieldOfView_mm.x);
-    BOOST_CHECK_EQUAL(head.encoding[0].reconSpace.fieldOfView_mm.y, model.encoding[0].reconSpace.fieldOfView_mm.y);
-    BOOST_CHECK_EQUAL(head.encoding[0].reconSpace.fieldOfView_mm.z, model.encoding[0].reconSpace.fieldOfView_mm.z);
-    BOOST_CHECK_EQUAL(head.encoding[0].trajectory, model.encoding[0].trajectory);
-    BOOST_CHECK_EQUAL(head.encoding[0].encodingLimits.kspace_encoding_step_1.get().minimum, model.encoding[0].encodingLimits.kspace_encoding_step_1.get().minimum);
-    BOOST_CHECK_EQUAL(head.encoding[0].encodingLimits.kspace_encoding_step_1.get().maximum, model.encoding[0].encodingLimits.kspace_encoding_step_1.get().maximum);
-    BOOST_CHECK_EQUAL(head.encoding[0].encodingLimits.kspace_encoding_step_1.get().center, model.encoding[0].encodingLimits.kspace_encoding_step_1.get().center);
-    BOOST_CHECK_EQUAL(head.encoding[0].encodingLimits.repetition.get().minimum, model.encoding[0].encodingLimits.repetition.get().minimum);
-    BOOST_CHECK_EQUAL(head.encoding[0].encodingLimits.repetition.get().maximum, model.encoding[0].encodingLimits.repetition.get().maximum);
-    BOOST_CHECK_EQUAL(head.encoding[0].encodingLimits.repetition.get().center, model.encoding[0].encodingLimits.repetition.get().center);
-    BOOST_CHECK_EQUAL(head.encoding[0].parallelImaging.get().accelerationFactor.kspace_encoding_step_1, model.encoding[0].parallelImaging.get().accelerationFactor.kspace_encoding_step_1);
-    BOOST_CHECK_EQUAL(head.encoding[0].parallelImaging.get().accelerationFactor.kspace_encoding_step_2, model.encoding[0].parallelImaging.get().accelerationFactor.kspace_encoding_step_2);
-    BOOST_CHECK_EQUAL(head.encoding[0].parallelImaging.get().calibrationMode, model.encoding[0].parallelImaging.get().calibrationMode);
+  BOOST_CHECK_EQUAL(head.studyInformation.get().studyDate, model.studyInformation.get().studyDate);
+  BOOST_CHECK_EQUAL(head.studyInformation.get().studyTime, model.studyInformation.get().studyTime);
+  BOOST_CHECK_EQUAL(head.studyInformation.get().studyDescription, model.studyInformation.get().studyDescription);
 
-    BOOST_CHECK_EQUAL(head.streams[0].label, model.streams[0].label);
-    BOOST_CHECK_EQUAL(head.streams[0].storageType, model.streams[0].storageType);
-    BOOST_CHECK_EQUAL(head.streams[0].entityType, model.streams[0].entityType);
-    BOOST_CHECK_EQUAL(head.streams[0].number, model.streams[0].number);
-    BOOST_CHECK_EQUAL(head.streams[1].label, model.streams[1].label);
-    BOOST_CHECK_EQUAL(head.streams[1].storageType, model.streams[1].storageType);
-    BOOST_CHECK_EQUAL(head.streams[1].entityType, model.streams[1].entityType);
-    BOOST_CHECK_EQUAL(head.streams[1].number, model.streams[1].number);
+  BOOST_CHECK_EQUAL(head.acquisitionSystemInformation.get().institutionName, model.acquisitionSystemInformation.get().institutionName);
+  BOOST_CHECK_EQUAL(head.acquisitionSystemInformation.get().receiverChannels, model.acquisitionSystemInformation.get().receiverChannels);
+  BOOST_CHECK_EQUAL(head.acquisitionSystemInformation.get().coilLabel[0].coilNumber, model.acquisitionSystemInformation.get().coilLabel[0].coilNumber);
+  BOOST_CHECK_EQUAL(head.acquisitionSystemInformation.get().coilLabel[0].coilName, model.acquisitionSystemInformation.get().coilLabel[0].coilName);
+  BOOST_CHECK_EQUAL(head.acquisitionSystemInformation.get().coilLabel[1].coilNumber, model.acquisitionSystemInformation.get().coilLabel[1].coilNumber);
+  BOOST_CHECK_EQUAL(head.acquisitionSystemInformation.get().coilLabel[1].coilName, model.acquisitionSystemInformation.get().coilLabel[1].coilName);
 
-    BOOST_CHECK_EQUAL(head.sequenceParameters.get().TR.get()[0], model.sequenceParameters.get().TR.get()[0]);
-    BOOST_CHECK_EQUAL(head.sequenceParameters.get().TE.get()[0], model.sequenceParameters.get().TE.get()[0]);
-    BOOST_CHECK_EQUAL(head.sequenceParameters.get().TE.get()[1], model.sequenceParameters.get().TE.get()[1]);
+  BOOST_CHECK_EQUAL(head.measurementInformation.get().measurementID, model.measurementInformation.get().measurementID);
+  BOOST_CHECK_EQUAL(head.measurementInformation.get().seriesDate, model.measurementInformation.get().seriesDate);
+  BOOST_CHECK_EQUAL(head.measurementInformation.get().seriesTime, model.measurementInformation.get().seriesTime);
+  BOOST_CHECK_EQUAL(head.measurementInformation.get().patientPosition, model.measurementInformation.get().patientPosition);
+  BOOST_CHECK_EQUAL(head.measurementInformation.get().protocolName, model.measurementInformation.get().protocolName);
+  BOOST_CHECK_EQUAL(head.measurementInformation.get().measurementDependency[0].dependencyType, model.measurementInformation.get().measurementDependency[0].dependencyType);
+  BOOST_CHECK_EQUAL(head.measurementInformation.get().measurementDependency[0].measurementID, model.measurementInformation.get().measurementDependency[0].measurementID);
+  BOOST_CHECK_EQUAL(head.measurementInformation.get().measurementDependency[1].dependencyType, model.measurementInformation.get().measurementDependency[1].dependencyType);
+  BOOST_CHECK_EQUAL(head.measurementInformation.get().measurementDependency[1].measurementID, model.measurementInformation.get().measurementDependency[1].measurementID);
 
-    BOOST_CHECK_EQUAL(head.userParameters.get().userParameterLong[0].name, model.userParameters.get().userParameterLong[0].name);
-    BOOST_CHECK_EQUAL(head.userParameters.get().userParameterLong[0].value, model.userParameters.get().userParameterLong[0].value);
-    BOOST_CHECK_EQUAL(head.userParameters.get().userParameterDouble[0].name, model.userParameters.get().userParameterDouble[0].name);
-    BOOST_CHECK_EQUAL(head.userParameters.get().userParameterDouble[0].value, model.userParameters.get().userParameterDouble[0].value);
+  BOOST_CHECK_EQUAL(head.encoding[0].encodedSpace.matrixSize.x, model.encoding[0].encodedSpace.matrixSize.x);
+  BOOST_CHECK_EQUAL(head.encoding[0].encodedSpace.matrixSize.y, model.encoding[0].encodedSpace.matrixSize.y);
+  BOOST_CHECK_EQUAL(head.encoding[0].encodedSpace.matrixSize.z, model.encoding[0].encodedSpace.matrixSize.z);
+  BOOST_CHECK_EQUAL(head.encoding[0].encodedSpace.fieldOfView_mm.x, model.encoding[0].encodedSpace.fieldOfView_mm.x);
+  BOOST_CHECK_EQUAL(head.encoding[0].encodedSpace.fieldOfView_mm.y, model.encoding[0].encodedSpace.fieldOfView_mm.y);
+  BOOST_CHECK_EQUAL(head.encoding[0].encodedSpace.fieldOfView_mm.z, model.encoding[0].encodedSpace.fieldOfView_mm.z);
+  BOOST_CHECK_EQUAL(head.encoding[0].reconSpace.matrixSize.x, model.encoding[0].reconSpace.matrixSize.x);
+  BOOST_CHECK_EQUAL(head.encoding[0].reconSpace.matrixSize.y, model.encoding[0].reconSpace.matrixSize.y);
+  BOOST_CHECK_EQUAL(head.encoding[0].reconSpace.matrixSize.z, model.encoding[0].reconSpace.matrixSize.z);
+  BOOST_CHECK_EQUAL(head.encoding[0].reconSpace.fieldOfView_mm.x, model.encoding[0].reconSpace.fieldOfView_mm.x);
+  BOOST_CHECK_EQUAL(head.encoding[0].reconSpace.fieldOfView_mm.y, model.encoding[0].reconSpace.fieldOfView_mm.y);
+  BOOST_CHECK_EQUAL(head.encoding[0].reconSpace.fieldOfView_mm.z, model.encoding[0].reconSpace.fieldOfView_mm.z);
+  BOOST_CHECK_EQUAL(head.encoding[0].trajectory, model.encoding[0].trajectory);
+  BOOST_CHECK_EQUAL(head.encoding[0].encodingLimits.kspace_encoding_step_1.get().minimum, model.encoding[0].encodingLimits.kspace_encoding_step_1.get().minimum);
+  BOOST_CHECK_EQUAL(head.encoding[0].encodingLimits.kspace_encoding_step_1.get().maximum, model.encoding[0].encodingLimits.kspace_encoding_step_1.get().maximum);
+  BOOST_CHECK_EQUAL(head.encoding[0].encodingLimits.kspace_encoding_step_1.get().center, model.encoding[0].encodingLimits.kspace_encoding_step_1.get().center);
+  BOOST_CHECK_EQUAL(head.encoding[0].encodingLimits.repetition.get().minimum, model.encoding[0].encodingLimits.repetition.get().minimum);
+  BOOST_CHECK_EQUAL(head.encoding[0].encodingLimits.repetition.get().maximum, model.encoding[0].encodingLimits.repetition.get().maximum);
+  BOOST_CHECK_EQUAL(head.encoding[0].encodingLimits.repetition.get().center, model.encoding[0].encodingLimits.repetition.get().center);
+  BOOST_CHECK_EQUAL(head.encoding[0].parallelImaging.get().accelerationFactor.kspace_encoding_step_1, model.encoding[0].parallelImaging.get().accelerationFactor.kspace_encoding_step_1);
+  BOOST_CHECK_EQUAL(head.encoding[0].parallelImaging.get().accelerationFactor.kspace_encoding_step_2, model.encoding[0].parallelImaging.get().accelerationFactor.kspace_encoding_step_2);
+  BOOST_CHECK_EQUAL(head.encoding[0].parallelImaging.get().calibrationMode, model.encoding[0].parallelImaging.get().calibrationMode);
 
-    BOOST_CHECK_EQUAL(head.userParameters.get().userParameterString[0].name, model.userParameters.get().userParameterString[0].name);
-    BOOST_CHECK_EQUAL(head.userParameters.get().userParameterString[0].value, model.userParameters.get().userParameterString[0].value);
-    BOOST_CHECK_EQUAL(head.userParameters.get().userParameterString[1].name, model.userParameters.get().userParameterString[1].name);
-    BOOST_CHECK_EQUAL(head.userParameters.get().userParameterString[1].value, model.userParameters.get().userParameterString[1].value);
+  BOOST_CHECK_EQUAL(head.streams[0].label, model.streams[0].label);
+  BOOST_CHECK_EQUAL(head.streams[0].storageType, model.streams[0].storageType);
+  BOOST_CHECK_EQUAL(head.streams[0].entityType, model.streams[0].entityType);
+  BOOST_CHECK_EQUAL(head.streams[0].number, model.streams[0].number);
+  BOOST_CHECK_EQUAL(head.streams[1].label, model.streams[1].label);
+  BOOST_CHECK_EQUAL(head.streams[1].storageType, model.streams[1].storageType);
+  BOOST_CHECK_EQUAL(head.streams[1].entityType, model.streams[1].entityType);
+  BOOST_CHECK_EQUAL(head.streams[1].number, model.streams[1].number);
+
+  BOOST_CHECK_EQUAL(head.sequenceParameters.get().TR.get()[0], model.sequenceParameters.get().TR.get()[0]);
+  BOOST_CHECK_EQUAL(head.sequenceParameters.get().TE.get()[0], model.sequenceParameters.get().TE.get()[0]);
+  BOOST_CHECK_EQUAL(head.sequenceParameters.get().TE.get()[1], model.sequenceParameters.get().TE.get()[1]);
+
+  BOOST_CHECK_EQUAL(head.userParameters.get().userParameterLong[0].name, model.userParameters.get().userParameterLong[0].name);
+  BOOST_CHECK_EQUAL(head.userParameters.get().userParameterLong[0].value, model.userParameters.get().userParameterLong[0].value);
+  BOOST_CHECK_EQUAL(head.userParameters.get().userParameterDouble[0].name, model.userParameters.get().userParameterDouble[0].name);
+  BOOST_CHECK_EQUAL(head.userParameters.get().userParameterDouble[0].value, model.userParameters.get().userParameterDouble[0].value);
+
+  BOOST_CHECK_EQUAL(head.userParameters.get().userParameterString[0].name, model.userParameters.get().userParameterString[0].name);
+  BOOST_CHECK_EQUAL(head.userParameters.get().userParameterString[0].value, model.userParameters.get().userParameterString[0].value);
+  BOOST_CHECK_EQUAL(head.userParameters.get().userParameterString[1].name, model.userParameters.get().userParameterString[1].name);
+  BOOST_CHECK_EQUAL(head.userParameters.get().userParameterString[1].value, model.userParameters.get().userParameterString[1].value);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Removed entity header from Acquisition, Image, Waveform entities
Removed entity header and entity inheritance from IsmrmrdHeader
Added IsmrmrdText entity class and implementation.
Updated test routines for changed entities, and added new for the IsmrmrdText
Dataset class formatting changes only.