### PR TITLE
install c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,6 +279,15 @@ install(
     Devel
 )
 
+install(
+  FILES
+    cmake/FindFFTW3.cmake
+  DESTINATION
+    ${ConfigPackageLocation}
+  COMPONENT
+    Devel
+)
+  
 # Create package
 string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
 include(${ISMRMRD_CMAKE_DIR}/ismrmrd_cpack.cmake)


### PR DESCRIPTION
gadgetron installs FindFFTW3.cmake but ismrmrd doesn't. In some cases, we want to build CCCPPETMR software that only depends on ismrmrd, so we need this.