### PR TITLE
Add ISMRMRDEXPORT statement in friend declaration of serialize

### DIFF
--- a/include/ismrmrd/meta.h
+++ b/include/ismrmrd/meta.h
@@ -166,7 +166,7 @@ namespace ISMRMRD
   {
     typedef std::map< std::string, std::vector<MetaValue> > map_t;
 
-    friend void serialize(MetaContainer& h, std::ostream& o);
+    friend void EXPORTISMRMRD serialize(MetaContainer& h, std::ostream& o);
 
   public:
     MetaContainer()


### PR DESCRIPTION
This is necessary on Windows to avoid "inconsistent dll linkage"
warnings. See e.g. https://groups.google.com/forum/#!topic/microsoft.public.vc.language/sq5_QPuJjgQ 