### PR TITLE
User string field in trajectory description and fractional acceleration factors

### DIFF
--- a/schema/ismrmrd.xsd
+++ b/schema/ismrmrd.xsd
@@ -182,6 +182,7 @@
       <xs:element maxOccurs="1" minOccurs="1" name="identifier" type="xs:string"/>
       <xs:element maxOccurs="unbounded" minOccurs="0" name="userParameterLong" type="userParameterLongType"/>
       <xs:element maxOccurs="unbounded" minOccurs="0" name="userParameterDouble" type="userParameterDoubleType"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="userParameterString" type="userParameterStringType"/>
       <xs:element maxOccurs="1" minOccurs="0" name="comment" type="xs:string"/>
     </xs:sequence>
   </xs:complexType>
@@ -243,8 +244,8 @@
 
   <xs:complexType name="accelerationFactorType">
     <xs:all>
-      <xs:element name="kspace_encoding_step_1" type="xs:unsignedShort"/>
-      <xs:element name="kspace_encoding_step_2" type="xs:unsignedShort"/>
+      <xs:element name="kspace_encoding_step_1" type="xs:double"/>
+      <xs:element name="kspace_encoding_step_2" type="xs:double"/>
     </xs:all>
   </xs:complexType>
 
@@ -275,8 +276,6 @@
   	 <xs:element maxOccurs="1" minOccurs="0" type="interleavingDimensionType" name="interleavingDimension"/>
   	</xs:sequence>
   </xs:complexType>
-
-
 
   <xs:complexType name="waveformInformation">
     <xs:sequence>


### PR DESCRIPTION
- Added user string to trajectory description in XML header for additional non numeric descriptive data, such as for example a trajectory basis type. For example "spherical harmonic basis" or any other descriptive information. It appears as if the user string type was simply forgotten in the trajectory description field?

- Changed the type of the accellerationFactor fields in the XML schema to double, in order to comply with for example Philips SENSE scan, which allow and commonly use fractional acceleration factors such as 2.3.