### PR TITLE
CMake: re-enable advanced version checking features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 foreach(p
     CMP0025 # CMake 3.0 Compiler id for Apple Clang is now ``AppleClang``.
     CMP0042 # CMake 3.0 ``MACOSX_RPATH`` is enabled by default.
@@ -198,6 +198,12 @@ set_target_properties(ismrmrd PROPERTIES
   VERSION ${ISMRMRD_VERSION_STRING}
   SOVERSION ${ISMRMRD_SOVERSION}
 )
+
+set_target_properties(ismrmrd
+  PROPERTIES
+  EXPORT_NAME ISMRMRD
+  INTERFACE_INCLUDE_DIRECTORIES $<INSTALL_INTERFACE:include/ismrmrd>)
+
 target_link_libraries(ismrmrd ${ISMRMRD_TARGET_LINK_LIBS})
 list(APPEND ISMRMRD_LIBRARIES ismrmrd) # Add to list of libraries to be found
 list(APPEND ISMRMRD_LIBRARY_DIRS ${CMAKE_BINARY_DIR} ) # Add to list of directories to find libraries
@@ -239,17 +245,9 @@ install(DIRECTORY matlab DESTINATION share/ismrmrd )
 
 #--- Create cmake package for downstream projects
 #
-##- include(CMakePackageConfigHelpers)
-##- write_basic_package_version_file(
-##-   "${CMAKE_CURRENT_BINARY_DIR}/ISMRMRDConfigVersion.cmake"
-##-   VERSION ${ISMRMRD_VERSION_STRING}
-##-   COMPATIBILITY AnyNewerVersion
-##- )
 
-##- export(EXPORT ISMRMRDTargets
-##-  FILE "${CMAKE_CURRENT_BINARY_DIR}/ISMRMRDTargets.cmake"
-##-  NAMESPACE ISMRMRD
-##-)
+include(CMakePackageConfigHelpers)
+set(INSTALL_CONFIGDIR lib/cmake/ISMRMRD)
 
 set(CONFIG_ISMRMRD_SCHEMA_DIR   ${ISMRMRD_SCHEMA_DIR})
 set(CONFIG_ISMRMRD_TARGET_INCLUDE_DIRS ${ISMRMRD_TARGET_INCLUDE_DIRS})
@@ -267,31 +265,47 @@ if (ISMRMRD_DATASET_SUPPORT)
   list(APPEND CONFIG_ISMRMRD_LIBRARY_DIRS ${HDF5_LIBRARY_DIRS})
   list(APPEND ISMRMRD_LIBRARIES ${HDF5_LIBRARIES})
 endif ()
-configure_file(cmake/ISMRMRDConfig.cmake.in
+
+configure_package_config_file(cmake/ISMRMRDConfig.cmake.in
   "${CMAKE_CURRENT_BINARY_DIR}/InstallFiles/ISMRMRDConfig.cmake"
-  @ONLY
-)
+  INSTALL_DESTINATION ${INSTALL_CONFIGDIR})
 
-set(ConfigPackageLocation lib/cmake/ISMRMRD)
-install(
-  FILES
-    "${CMAKE_CURRENT_BINARY_DIR}/InstallFiles/ISMRMRDConfig.cmake"
-#--    "${CMAKE_CURRENT_BINARY_DIR}/ISMRMRDConfigVersion.cmake"
-  DESTINATION
-    ${ConfigPackageLocation}
-  COMPONENT
-    Devel
-)
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/ISMRMRDConfigVersion.cmake"
+  VERSION ${ISMRMRD_VERSION_STRING}
+  COMPATIBILITY SameMajorVersion
+  )
 
-install(
-  FILES
-    cmake/FindFFTW3.cmake
-  DESTINATION
-    ${ConfigPackageLocation}
-  COMPONENT
-    Devel
-)
-  
+# Write a CMake file with all the targets information
+# (not for installing, but for external project to import targets from the
+#  current build tree)
+if(CMAKE_VERSION VERSION_LESS 3.0)
+  export(TARGETS ismrmrd
+    FILE ${CMAKE_CURRENT_BINARY_DIR}/ISMRMRDTargets.cmake
+    NAMESPACE ISMRMRD::
+    )
+else()
+  export(EXPORT ISMRMRDTargets
+    FILE ${CMAKE_CURRENT_BINARY_DIR}/ISMRMRDTargets.cmake
+    NAMESPACE ISMRMRD::
+    )
+endif()
+
+install(EXPORT ISMRMRDTargets
+  FILE ISMRMRDTargets.cmake
+  NAMESPACE ISMRMRD::
+  DESTINATION ${INSTALL_CONFIGDIR}
+  )
+
+install(FILES
+  cmake/FindFFTW3.cmake
+  "${CMAKE_CURRENT_BINARY_DIR}/ISMRMRDConfigVersion.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/InstallFiles/ISMRMRDConfig.cmake"
+  DESTINATION ${INSTALL_CONFIGDIR}
+  COMPONENT Devel)
+
+export(PACKAGE ISMRMRD)
+ 
 # Create package
 string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
 include(${ISMRMRD_CMAKE_DIR}/ismrmrd_cpack.cmake)

--- a/cmake/ISMRMRDConfig.cmake.in
+++ b/cmake/ISMRMRDConfig.cmake.in
@@ -4,14 +4,12 @@
 #
 # This file is configured by ISMRMRD and used by the UseISMRMRD.cmake module
 # to load ISMRMRD's settings for an external project.
-@ISMRMRD_CONFIG_CODE@
 
-##- include(${CMAKE_CURRENT_LIST_DIR}/ISMRMRDConfigVersion.cmake)
+@PACKAGE_INIT@
 
-# The ISMRMRD version number
-set(ISMRMRD_VERSION_MAJOR "@ISMRMRD_VERSION_MAJOR@")
-set(ISMRMRD_VERSION_MINOR "@ISMRMRD_VERSION_MINOR@")
-set(ISMRMRD_VERSION_PATCH "@ISMRMRD_VERSION_PATCH@")
+get_filename_component(ISMRMRD_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
+include(${ISMRMRD_CMAKE_DIR}/ISMRMRDConfigVersion.cmake)
 
 #   ISMRMRD_SCHEMA_DIR   - where to find ismrmrd.xsd 
 set(ISMRMRD_SCHEMA_DIR   "@CONFIG_ISMRMRD_SCHEMA_DIR@")
@@ -22,8 +20,36 @@ set(ISMRMRD_LIBRARY_DIRS "@CONFIG_ISMRMRD_LIBRARY_DIRS@")
 #   ISMRMRD_LIBRARIES    - i.e. ismrmrd
 set(ISMRMRD_LIBRARIES    "@ISMRMRD_LIBRARIES@")
 
+set(USE_SYSTEM_PUGIXML @USE_SYSTEM_PUGIXML@)
+
 ## For backwards compatibility use existing variable name
 ## Include directories can be lists, and should be plural
 ## to conform with naming schemes in many other cmake packages
 set(ISMRMRD_INCLUDE_DIR  "@CONFIG_ISMRMRD_TARGET_INCLUDE_DIRS@")
 set(ISMRMRD_LIB_DIR "@CONFIG_ISMRMRD_LIBRARY_DIRS@")
+
+# ------------------------------------------------------------------------------
+
+include(CMakeFindDependencyMacro)
+
+list(INSERT CMAKE_MODULE_PATH 0 ${ISMRMRD_CMAKE_DIR})
+
+if(USE_SYSTEM_PUGIXML)
+  find_dependency(PugiXML)
+endif()
+
+if(CMAKE_VERSION VERSION_LESS 3.9)
+  # CMake <= 3.8 find_dependency does not support COMPONENTS
+  find_package(HDF5 COMPONENTS C)
+else()
+  find_dependency(HDF5 COMPONENTS C)
+endif()
+
+list(REMOVE_AT CMAKE_MODULE_PATH 0)
+
+# ==============================================================================
+
+set_and_check(ISMRMRDTargets "${ISMRMRD_CMAKE_DIR}/ISMRMRDTargets.cmake")
+include(${ISMRMRDTargets})
+
+# ==============================================================================


### PR DESCRIPTION
The changes proposed here are compatible with all major versions of CMake since CMake 2.8.12 which is now 5 years old (Ubuntu 14.04 or Debian jessie required).