### PR TITLE
Revert "add a member function to return all keys in a meta container"

### DIFF
--- a/include/ismrmrd/meta.h
+++ b/include/ismrmrd/meta.h
@@ -244,18 +244,6 @@ namespace ISMRMRD
         return map_.empty();
     }
 
-    void get_all_keys(std::vector<std::string>& keys)
-    {
-        keys.clear();
-
-        MetaContainer::map_t::iterator it = this->map_.begin();
-        while (it != this->map_.end())
-        {
-            keys.push_back(it->first);
-            it++;
-        }
-    }
-
   protected:
     map_t map_; 
   };


### PR DESCRIPTION
Reverts ismrmrd/ismrmrd#118

Please don't add things to ismrmrd without external review. 
It has much larger repercussions than when doing so in Gadgetron.

We can have the function if needed, but returning through a reference is just bad practice. 