### PR TITLE
Fix some MetaContainer inheritance and const issues

### DIFF
--- a/include/ismrmrd/meta.h
+++ b/include/ismrmrd/meta.h
@@ -149,6 +149,7 @@ namespace ISMRMRD {
 
     /// Meta Container
     class MetaContainer {
+    protected:
         typedef std::map<std::string, std::vector<MetaValue> > map_t;
 
     public:
@@ -216,7 +217,7 @@ namespace ISMRMRD {
             return it->second[index];
         }
 
-        bool empty() {
+        bool empty() const {
             return map_.empty();
         }
 


### PR DESCRIPTION
- make typedef map_t protected instead of private because protected variable of type map_t exists.
- make empty() const as it does not change the object.