### PR TITLE
fix boost::program_options linking error

### DIFF
--- a/utilities/CMakeLists.txt
+++ b/utilities/CMakeLists.txt
@@ -22,6 +22,11 @@ if (HDF5_FOUND)
     install(TARGETS ismrmrd_read_timing_test DESTINATION bin)
 
     find_package(Boost 1.43 COMPONENTS program_options)
+    if (WIN32)
+        add_definitions(-DBOOST_ALL_NO_LIB)
+        add_definitions(-DBOOST_ALL_DYN_LINK)
+    endif()
+
     find_package(FFTW3 COMPONENTS single)
 
     if(FFTW3_FOUND AND Boost_FOUND)


### PR DESCRIPTION
On Windows, I need `BOOST_ALL_NO_LIB` to prevent double linking errors and `BOOST_ALL_DYN_LINK` to prevent linking errors due to missing variables ` boost::program_options::arg` and `boost::program_options::options_description::m_default_line_length`.

Tested with Boost 1.69.0, VS2015 and CMake 3.13.2.