### PR TITLE
GE-compat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,7 +235,9 @@ endif ()
 
 # TODO: make this work on Windows
 if (NOT WIN32)
-    add_subdirectory(tests)
+   if (NOT Boost_USE_STATIC_LIBS)
+      add_subdirectory(tests)
+   endif ()
 endif ()
 
 # install the matlab api

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ if (WIN32)
     add_definitions(-D__func__=__FUNCTION__)
 else ()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -Wall")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++11")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w    -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=0")
 endif ()
 
 #  ---   VERSIONING  (begin) ----

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,11 @@ foreach(p
 endforeach()
 project(ISMRMRD)
 
+message("")
+message("*** Please remember to have environment variables SDKTOP and HDF5_ROOT set, so ***")
+message("*** cmake will configure ISMRMRD build to use these components from Orchestra. ***")
+message("")
+
 # set project specific cmake module path
 set (ISMRMRD_CMAKE_DIR ${PROJECT_SOURCE_DIR}/cmake CACHE PATH
   "Location of CMake scripts")
@@ -45,8 +50,13 @@ if (WIN32)
     set(CMAKE_MODULE_LINKER_FLAGS_DEBUG "/debug /INCREMENTAL:NO")
     add_definitions(-D__func__=__FUNCTION__)
 else ()
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -Wall")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w    -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=0")
+    set(Boost_USE_STATIC_LIBS       "ON")
+    set(Boost_NO_SYSTEM_PATHS       "TRUE")
+    set(BOOST_ROOT                  "$ENV{SDKTOP}/3p")
+    set(HDF5_USE_STATIC_LIBRARIES   "yes")
+    set(CMAKE_C_FLAGS               "${CMAKE_C_FLAGS} -std=c99 -Wall")
+    set(CMAKE_CXX_FLAGS             "${CMAKE_CXX_FLAGS} -w -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=0")
+    set(CMAKE_EXE_LINKER_FLAGS      "-lpthread -lz -ldl")
 endif ()
 
 #  ---   VERSIONING  (begin) ----

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,7 @@ if (NOT Boost_UNIT_TEST_FRAMEWORK_FOUND)
 endif ()
 
 if (NOT Boost_USE_STATIC_LIBS)
-    add_compile_definitions(BOOST_TEST_DYN_LINK)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_TEST_DYN_LINK")
 endif()
 
 include_directories(${CMAKE_SOURCE_DIR}/include ${CMAKE_BINARY_DIR}/include ${Boost_INCLUDE_DIR})


### PR DESCRIPTION
These modifications to the build configuration set ISMRMRD to build using GE's static Boost and HDF libraries.  These seem to be necessary to configure the build process when using Orchestra 1.8 as the basis for the converter.

Also - these changes should probably stay in a secondary branch ('GE-compat' would be great) if accepted for a 'merge' back into origin repository.