### PR TITLE
Change linking to system libraries that Orchestra's HDF5 needs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,6 @@ elseif (build4GE)
     set(HDF5_USE_STATIC_LIBRARIES   "yes")
     set(CMAKE_C_FLAGS               "${CMAKE_C_FLAGS} -std=c99 -Wall")
     set(CMAKE_CXX_FLAGS             "${CMAKE_CXX_FLAGS} -w -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=0")
-    set(CMAKE_EXE_LINKER_FLAGS      "-lpthread -lz -ldl")
 else ()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -Wall")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++11")
@@ -208,6 +207,10 @@ if (USE_SYSTEM_PUGIXML)
     endif ()
 else ()
     list(APPEND ISMRMRD_TARGET_SOURCES libsrc/pugixml.cpp)
+endif ()
+
+if (build4GE)
+   list(APPEND ISMRMRD_TARGET_LINK_LIBS pthread z dl)
 endif ()
 
 # main library


### PR DESCRIPTION
This should improve behavior when building ISMRMRD against Orchestra's HDF5 libraries on Ubuntu.

This was one of the issues raised [here](https://github.com/ismrmrd/ge_to_ismrmrd/issues/9), and a resolution was found [here](https://github.com/ismrmrd/ge_to_ismrmrd/issues/9#issuecomment-672131789).