### PR TITLE
Fix erroneous use of float_t in recon_cartesian_2d

### DIFF
--- a/utilities/recon_cartesian_2d.cpp
+++ b/utilities/recon_cartesian_2d.cpp
@@ -139,7 +139,7 @@ int main(int argc, char** argv)
 
     //Allocate an image
     ISMRMRD::Image<float> img_out(r_space.matrixSize.x, r_space.matrixSize.y, 1, 1);
-    memset(img_out.getDataPtr(), 0, sizeof(float_t)*r_space.matrixSize.x*r_space.matrixSize.y);
+    memset(img_out.getDataPtr(), 0, sizeof(float)*r_space.matrixSize.x*r_space.matrixSize.y);
            
     //f there is oversampling in the readout direction remove it
     //Take the sqrt of the sum of squares


### PR DESCRIPTION
The call to memset uses the type float_t for calculating the area to
clear. However, the actual size of the underlying allocation is based on
the type float, as a result of how the Image is defined a few lines
above. In general, float_t and float are not necessarily the same. For
example, on x86 with -mfpmath=sse+387, float_t becomes long double; on
other architectures these types may differ generally. When that is the
case, the memset would perform an out-of-bounds access.

Fix to directly use sizeof(float).

Fixes #163