### PR TITLE
Add DLL symbol export for function ismrmrd_sizeof_data_type.

### DIFF
--- a/include/ismrmrd/ismrmrd.h
+++ b/include/ismrmrd/ismrmrd.h
@@ -126,7 +126,7 @@ enum ISMRMRD_DataTypes {
 };
 
 /** Returns the size in bytes of an ISMRMRD_DataType */
-size_t ismrmrd_sizeof_data_type(int data_type);
+EXPORTISMRMRD size_t ismrmrd_sizeof_data_type(int data_type);
 
 /**
  * Acquisition Flags


### PR DESCRIPTION
Without this export, test_ismrmrd.exe isn't able to build.