### PR TITLE
Fix PugiXML variable name

### DIFF
--- a/cmake/ISMRMRDConfig.cmake.in
+++ b/cmake/ISMRMRDConfig.cmake.in
@@ -36,7 +36,7 @@ list(INSERT CMAKE_MODULE_PATH 0 ${ISMRMRD_CMAKE_DIR})
 
 if(USE_SYSTEM_PUGIXML)
   find_package(PugiXML CONFIG)
-  if (NOT PUGIXML_FOUND)
+  if (NOT PugiXML_FOUND)
     find_dependency(PugiXML)
   endif()
 endif()


### PR DESCRIPTION
This was making the testsuite fail because with new PugiXML the find_package can't be done twice anymore
See: https://github.com/zeux/pugixml/issues/393