### PR TITLE
Update README.md: MacPorts installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ sudo make install
 This will install the library in `/usr/local/` by default. To specify
 an alternative installation directory, pass `-D CMAKE_INSTALL_PREFIX=<install dir>` to `cmake`.
 
+### macOS installation
+
+ISMRMRD and its dependencies can be installed via MacPorts (https://macports.org) with:
+
+```
+sudo port install ismrmrd
+```
+
+This will install the library, binaries, documentation, and examples into `/opt/local` by default. Changing the default MacPorts directory is not recommended as it prevents using pre-compiled packages.
+
 # Format Details
 
 The raw data format combines a mix of flexible data structures (XML header) and fixed structures (equivalent to C-structs). A raw data set consist mainly of 2 sections:


### PR DESCRIPTION
Document that MacPorts can be used to install ismrmrd directly on macOS. Pre-compiled binaries are used to perform the installation so long as the default MacPorts installation options (location & permissions) are used.