### PR TITLE
Added automatic creation of schema documentation.

### DIFF
--- a/doc/create_ismrmrd_documentation.xsl
+++ b/doc/create_ismrmrd_documentation.xsl
@@ -1,0 +1,282 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.w3.org/1999/xhtml">
+
+<xsl:variable name="types">
+                <xsl:for-each select="/xs:schema/xs:complexType">
+                  <xsl:value-of select="@name"/>
+                  <xsl:if test="position()!=last()">
+                    <xsl:value-of select="'|'"/>
+                  </xsl:if>
+                </xsl:for-each>
+</xsl:variable>
+
+<xsl:variable name="simpletypes">
+                <xsl:for-each select="/xs:schema/xs:simpleType">
+                  <xsl:value-of select="@name"/>
+                  <xsl:if test="position()!=last()">
+                    <xsl:value-of select="'|'"/>
+                  </xsl:if>
+                </xsl:for-each>
+</xsl:variable>
+
+<xsl:template match="/xs:schema">
+<svg preserveAspectRatio="xMidYMin meet" y="0"  viewBox="0 0 2000 5500" width="100%"  height="600%" xmlns="http://www.w3.org/2000/svg">
+  <foreignObject width="100%" height="100%">
+    <div xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8"></meta>
+    <title>MRD header schema documentation</title>
+	<style type="text/css">
+		html {
+				font-family: sans-serif;
+			}
+				td, th {
+				  border: 0.05rem solid rgb(0,0,0);
+				  padding: 0.25rem 0.5rem;
+				}
+				td {
+				  text-align: center;
+				  word-wrap: break-word;
+				  overflow-wrap: break-word;
+				  vertical-align: top;
+				}
+				table {
+				  border-collapse: collapse;
+				  border: 0.1rem solid rgb(0,0,0);
+				  letter-spacing: 0.05rem;
+				  font-size: 0.8rem;
+				}
+
+				thead th { 
+				text-align:left; 
+				background:black; 
+				color:white
+				}
+
+				tbody tr:nth-child(odd) > td,
+				tfoot tr:nth-child(odd) > td,
+				tr:nth-child(odd) > td
+				{ 
+				background:rgb(238, 238, 238); 
+				}
+
+				tbody tr:nth-child(even) > td,
+				tfoot tr:nth-child(even) > td,
+				tr:nth-child(even) > td
+				{ 
+				background:rgb(215, 215, 215);
+				}
+
+				tbody table tbody tr:nth-child(odd) > td,
+				tbody table tfoot tr:nth-child(odd) > td,
+				tbody table tr:nth-child(odd) > td
+				{ 
+				background:rgb(255, 255, 99) ; 
+				}
+
+				tbody table tbody tr:nth-child(even) > td,
+				tbody table tfoot tr:nth-child(even) > td,
+				tbody table tr:nth-child(even) > td
+				{ 
+				background:rgb(229, 220, 59);
+				}
+
+				tbody table tbody table tbody tr:nth-child(odd) > td,
+				tbody table tbody table tbody tfoot tr:nth-child(odd) > td,
+				tbody table tbody table tbody tr:nth-child(odd) > td
+				{ 
+				background:rgb(40, 255, 255) 
+				}
+
+				tbody table tbody table tbody tr:nth-child(even) > td,
+				tbody table tbody table tbody tfoot tr:nth-child(even) > td,
+				tbody table tbody table tbody tr:nth-child(even) > td
+				{ 
+				background:rgb(20, 207, 235) 
+				}
+
+				tbody table tbody table tbody table tbody tr:nth-child(odd) > td,
+				tbody table tbody table tbody table tbody tfoot tr:nth-child(odd) > td,
+				tbody table tbody table tbody table tbody tr:nth-child(odd) > td
+				{
+				background:rgb(255, 123, 221) ; 
+				}
+
+				tbody table tbody table tbody table tbody tr:nth-child(even) > td,
+				tbody table tbody table tbody table tbody tfoot tr:nth-child(even) > td,
+				tbody table tbody table tbody table tbody tr:nth-child(even) > td
+				{
+				background:rgb(255, 83, 191) ; 
+				}
+	</style>
+</head>
+<body>
+	<xsl:apply-templates select="xs:element"/>
+</body>
+</div>
+  </foreignObject>
+</svg>
+</xsl:template>
+
+<xsl:template match="xs:complexType">
+  <td> 
+  <table>
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Type</th>
+                <th>Multiplicity</th>
+				<xsl:variable name="annotationNodes"><xsl:value-of select="descendant-or-self::xs:annotation" /></xsl:variable>
+				<xsl:if test="not($annotationNodes='')">
+					<th>Description</th>
+				</xsl:if>
+            </tr>
+        </thead>
+        <tbody>
+		<xsl:apply-templates/>
+		</tbody>
+  </table>
+  </td>
+</xsl:template>
+
+<xsl:template match="xs:simpleType">
+  <td>
+  <xsl:value-of select="xs:restriction/@base" />
+  </td>
+</xsl:template>
+
+<xsl:template match="xs:simpleType/xs:restriction[xs:pattern]">
+      Pattern is: <xsl:value-of select="xs:pattern/@value" />
+</xsl:template>
+
+<xsl:template match="xs:simpleType/xs:restriction[xs:enumeration]">
+      Enumeration is: <xsl:apply-templates select="xs:enumeration"/>
+</xsl:template>
+
+<xsl:template match="xs:enumeration">
+      <br/> <xsl:value-of select="@value" />
+</xsl:template>
+
+<xsl:template match="xs:annotation">
+      <xsl:value-of select="xs:documentation" />
+</xsl:template>
+
+<xsl:template match="xs:element[@type]">
+	<xsl:choose>
+	<xsl:when test="@type='ismrmrdHeader'">
+		<xsl:for-each select="/xs:schema/xs:complexType">
+			<xsl:if test="'ismrmrdHeader'=@name">		
+			<table>
+				<thead>
+					<tr>
+						<th>Name</th>
+						<th>Type</th>
+						<th>Multiplicity</th>
+						<th>Description</th>
+					</tr>
+				</thead>
+				<tbody>
+				<xsl:apply-templates/>
+				</tbody>
+			</table>
+			</xsl:if>
+		</xsl:for-each>
+	</xsl:when>
+	<xsl:otherwise>
+		    <tr>
+        <td> <xsl:value-of select="@name" /> </td>
+				<xsl:choose>
+					<xsl:when test="contains($types, @type)">
+					 <xsl:variable name="currentType"><xsl:value-of select="@type" /></xsl:variable>
+						<xsl:for-each select="/xs:schema">
+								<xsl:apply-templates select="xs:complexType[$currentType=@name]"/>
+						</xsl:for-each>
+					</xsl:when>
+					<xsl:when test="contains($simpletypes, @type)">
+					 <xsl:variable name="currentType"><xsl:value-of select="@type" /></xsl:variable>
+						<xsl:for-each select="/xs:schema">
+								<xsl:apply-templates select="xs:simpleType[$currentType=@name]"/>
+						</xsl:for-each>
+					</xsl:when>
+					<xsl:otherwise>
+						<td> <xsl:value-of select="@type" /> </td>
+					</xsl:otherwise>
+				  </xsl:choose>
+				<td>  
+			<xsl:choose>
+					<xsl:when test="@minOccurs and @maxOccurs and @maxOccurs='unbounded'">
+						<xsl:value-of select="@minOccurs" /> - 4096
+					</xsl:when>
+					<xsl:when test="@minOccurs and @maxOccurs">
+						<xsl:choose>
+						<xsl:when test="@minOccurs=@maxOccurs">
+							<xsl:value-of select="@minOccurs" />
+						</xsl:when>
+						<xsl:otherwise>
+						<xsl:value-of select="@minOccurs" /> - <xsl:value-of select="@maxOccurs" />
+					</xsl:otherwise>
+				  </xsl:choose>
+					</xsl:when>
+					<xsl:when test="@minOccurs and @minOccurs='0'">
+						<xsl:value-of select="@minOccurs" /> - 1
+					</xsl:when>
+					<xsl:when test="@minOccurs">
+						<xsl:value-of select="@minOccurs" />
+					</xsl:when>
+					<xsl:otherwise>
+						1
+					</xsl:otherwise>
+				  </xsl:choose>
+		</td>
+		<xsl:variable name="annotationNodes"><xsl:value-of select="descendant-or-self::xs:annotation" /></xsl:variable>
+		<xsl:if test="not($annotationNodes='')">
+		<td> 
+			<xsl:apply-templates select="xs:annotation"/> 
+			<xsl:if test="contains($simpletypes, @type)">
+					 <xsl:variable name="currentType"><xsl:value-of select="@type" /></xsl:variable>
+						<xsl:for-each select="/xs:schema">
+								<xsl:apply-templates select="xs:simpleType[$currentType=@name]/xs:restriction[xs:enumeration]"/>
+						</xsl:for-each>
+					</xsl:if>
+		</td>
+		</xsl:if>
+	</tr>
+	</xsl:otherwise>
+	</xsl:choose>
+</xsl:template>
+
+<xsl:template match="xs:element[not(@type)]">
+	<tr>
+        <td> <xsl:value-of select="@name" /> </td>			
+		<td> <xsl:value-of select="xs:simpleType/xs:restriction/@base" /> </td>
+		<td>  
+						<xsl:choose>
+					<xsl:when test="@minOccurs and @maxOccurs and @maxOccurs='unbounded'">
+						<xsl:value-of select="@minOccurs" /> - 4096
+					</xsl:when>
+					<xsl:when test="@minOccurs and @maxOccurs">
+						<xsl:value-of select="@minOccurs" /> - <xsl:value-of select="@maxOccurs" />
+					</xsl:when>
+					<xsl:when test="@minOccurs and @minOccurs='0'">
+						<xsl:value-of select="@minOccurs" /> - 1
+					</xsl:when>
+					<xsl:when test="@minOccurs">
+						<xsl:value-of select="@minOccurs" />
+					</xsl:when>
+					<xsl:otherwise>
+						1
+					</xsl:otherwise>
+				  </xsl:choose>
+		</td>
+		<xsl:variable name="annotationNodes"><xsl:value-of select="descendant-or-self::xs:annotation" /></xsl:variable>
+		<xsl:if test="not($annotationNodes='')">
+			<td> 
+				<xsl:apply-templates select="xs:annotation"/>
+				<xsl:apply-templates select="xs:simpleType/xs:restriction[xs:pattern]"/>
+				<xsl:apply-templates select="xs:simpleType/xs:restriction[xs:enumeration]"/>
+			</td>
+		</xsl:if>
+	</tr>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/doc/current_schema_documentation.svg
+++ b/doc/current_schema_documentation.svg
@@ -1,0 +1,527 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xs="http://www.w3.org/2001/XMLSchema" preserveAspectRatio="xMidYMin meet" y="0" viewBox="0 0 2000 5500" width="100%" height="600%"><foreignObject width="100%" height="100%"><div xmlns="http://www.w3.org/1999/xhtml"><head><meta charset="utf-8"/><title>MRD header schema documentation</title><style type="text/css">
+		html {
+				font-family: sans-serif;
+			}
+				td, th {
+				  border: 0.05rem solid rgb(0,0,0);
+				  padding: 0.25rem 0.5rem;
+				}
+				td {
+				  text-align: center;
+				  word-wrap: break-word;
+				  overflow-wrap: break-word;
+				  vertical-align: top;
+				}
+				table {
+				  border-collapse: collapse;
+				  border: 0.1rem solid rgb(0,0,0);
+				  letter-spacing: 0.05rem;
+				  font-size: 0.8rem;
+				}
+
+				thead th { 
+				text-align:left; 
+				background:black; 
+				color:white
+				}
+
+				tbody tr:nth-child(odd) &gt; td,
+				tfoot tr:nth-child(odd) &gt; td,
+				tr:nth-child(odd) &gt; td
+				{ 
+				background:rgb(238, 238, 238); 
+				}
+
+				tbody tr:nth-child(even) &gt; td,
+				tfoot tr:nth-child(even) &gt; td,
+				tr:nth-child(even) &gt; td
+				{ 
+				background:rgb(215, 215, 215);
+				}
+
+				tbody table tbody tr:nth-child(odd) &gt; td,
+				tbody table tfoot tr:nth-child(odd) &gt; td,
+				tbody table tr:nth-child(odd) &gt; td
+				{ 
+				background:rgb(255, 255, 99) ; 
+				}
+
+				tbody table tbody tr:nth-child(even) &gt; td,
+				tbody table tfoot tr:nth-child(even) &gt; td,
+				tbody table tr:nth-child(even) &gt; td
+				{ 
+				background:rgb(229, 220, 59);
+				}
+
+				tbody table tbody table tbody tr:nth-child(odd) &gt; td,
+				tbody table tbody table tbody tfoot tr:nth-child(odd) &gt; td,
+				tbody table tbody table tbody tr:nth-child(odd) &gt; td
+				{ 
+				background:rgb(40, 255, 255) 
+				}
+
+				tbody table tbody table tbody tr:nth-child(even) &gt; td,
+				tbody table tbody table tbody tfoot tr:nth-child(even) &gt; td,
+				tbody table tbody table tbody tr:nth-child(even) &gt; td
+				{ 
+				background:rgb(20, 207, 235) 
+				}
+
+				tbody table tbody table tbody table tbody tr:nth-child(odd) &gt; td,
+				tbody table tbody table tbody table tbody tfoot tr:nth-child(odd) &gt; td,
+				tbody table tbody table tbody table tbody tr:nth-child(odd) &gt; td
+				{
+				background:rgb(255, 123, 221) ; 
+				}
+
+				tbody table tbody table tbody table tbody tr:nth-child(even) &gt; td,
+				tbody table tbody table tbody table tbody tfoot tr:nth-child(even) &gt; td,
+				tbody table tbody table tbody table tbody tr:nth-child(even) &gt; td
+				{
+				background:rgb(255, 83, 191) ; 
+				}
+	</style></head><body><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th><th>Description</th></tr></thead><tbody>
+    
+      <tr><td>version</td><td>xs:long</td><td>0 - 1</td><td>Major version of ISMRMRD.</td></tr>
+      <tr><td>subjectInformation</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th><th>Description</th></tr></thead><tbody>
+    
+      <tr><td>patientName</td><td>xs:string</td><td>0 - 1
+					</td><td>Patient's full name.</td></tr>
+      <tr><td>patientWeight_kg</td><td>xs:float</td><td>0 - 1
+					</td><td>Patient's weight in kg.</td></tr>
+      <tr><td>patientID</td><td>xs:string</td><td>0 - 1
+					</td><td>Primary identifier for the Patient.</td></tr>
+      <tr><td>patientBirthdate</td><td>xs:date</td><td>0 - 1
+					</td><td>Birth date of the Patient. YYYY-MM-DD.</td></tr>
+      <tr><td>patientGender</td><td>xs:string</td><td>0 - 1
+					</td><td>Gender of the named Patient.
+      Pattern is: [MFO]</td></tr>
+    
+  </tbody></table></td><td>0 - 1</td><td>Information about the scanned patient.</td></tr>
+      <tr><td>studyInformation</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th><th>Description</th></tr></thead><tbody>
+    
+      <tr><td>studyDate</td><td>xs:date</td><td>0 - 1</td><td>Date the Study started.</td></tr>
+      <tr><td>studyTime</td><td>xs:time</td><td>0 - 1</td><td>Time the Study started.</td></tr>
+      <tr><td>studyID</td><td>xs:string</td><td>0 - 1</td><td>User or equipment-generated Study identifier.</td></tr>
+      <tr><td>accessionNumber</td><td>xs:long</td><td>0 - 1</td><td>A RIS generated number that identifies the order for the Study.</td></tr>
+      <tr><td>referringPhysicianName</td><td>xs:string</td><td>0 - 1</td><td>Name of the Patient's referring physician</td></tr>
+      <tr><td>studyDescription</td><td>xs:string</td><td>0 - 1</td><td>Institution-generated description or classification of the Study (component) performed.</td></tr>
+      <tr><td>studyInstanceUID</td><td>xs:string</td><td>0 - 1</td><td>Unique identifier for the Study.</td></tr>
+    
+  </tbody></table></td><td>0 - 1</td><td>Information about the study for which this data was acquired if any.</td></tr>
+	  <tr><td>measurementInformation</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th><th>Description</th></tr></thead><tbody>
+    
+      <tr><td>measurementID</td><td>xs:string</td><td>0 - 1
+					</td><td>Unique identifier of the measurement.</td></tr>
+      <tr><td>seriesDate</td><td>xs:date</td><td>0 - 1
+					</td><td>Date the Series started.</td></tr>
+      <tr><td>seriesTime</td><td>xs:time</td><td>0 - 1
+					</td><td>Time the Series started.</td></tr>
+      <tr><td>patientPosition</td><td>xs:string</td><td>1</td><td>Patient position descriptor relative to the equipment.
+      Enumeration is: <br/>HFP<br/>HFS<br/>HFDR<br/>HFDL<br/>FFP<br/>FFS<br/>FFDR<br/>FFDL</td></tr>
+      <tr><td>initialSeriesNumber</td><td>xs:long</td><td>0 - 1
+					</td><td>Next available series number in the study.</td></tr>
+      <tr><td>protocolName</td><td>xs:string</td><td>0 - 1
+					</td><td>User-defined description of the conditions under which the Series was performed.</td></tr>
+      <tr><td>seriesDescription</td><td>xs:string</td><td>0 - 1
+					</td><td>Description of the Series.</td></tr>
+      <tr><td>measurementDependency</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th><th>Description</th></tr></thead><tbody>
+    
+      <tr><td>dependencyType</td><td>xs:string</td><td>1</td><td>Describes the purpose for which the reference is made. E.g. "Noise".</td></tr>
+      <tr><td>measurementID</td><td>xs:string</td><td>1</td><td>Unique identifier of dependent measurement.</td></tr>
+    
+  </tbody></table></td><td>0 - 4096
+					</td><td>Identification of measurement related to this measurement. One or more Items are permitted in this Sequence.</td></tr>
+      <tr><td>seriesInstanceUIDRoot</td><td>xs:string</td><td>0 - 1
+					</td><td>First portion of the series unique identifier.</td></tr>
+      <tr><td>frameOfReferenceUID</td><td>xs:string</td><td>0 - 1
+					</td><td>Unique identifier for the frame of reference the data was collected in. Data with the same frame of reference can be combined.</td></tr>
+      <tr><td>referencedImageSequence</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th><th>Description</th></tr></thead><tbody>
+    
+      <tr><td>referencedSOPInstanceUID</td><td>xs:string</td><td>0 - 4096
+					</td><td>Uniquely identifies the referenced SOP Instance.</td></tr>
+    
+  </tbody></table></td><td>0 - 1
+					</td><td>Other images significantly related to this image.</td></tr>
+    
+  </tbody></table></td><td>0 - 1</td><td>General information about this measurement and its relation to other measurements.</td></tr>
+      <tr><td>acquisitionSystemInformation</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th><th>Description</th></tr></thead><tbody>
+    
+      <tr><td>systemVendor</td><td>xs:string</td><td>0 - 1</td><td>Manufacturer of the device.</td></tr>
+      <tr><td>systemModel</td><td>xs:string</td><td>0 - 1</td><td>Manufacturer's model name of the device.</td></tr>
+      <tr><td>systemFieldStrength_T</td><td>xs:float</td><td>0 - 1</td><td>Fieldstrength of the device in Tesla.</td></tr>
+      <tr><td>relativeReceiverNoiseBandwidth</td><td>xs:float</td><td>0 - 1</td><td>Effective bandwidth of noise measurement data as fraction.</td></tr>
+      <tr><td>receiverChannels</td><td>xs:unsignedShort</td><td>0 - 1</td><td>Count of coils used for this measurement.</td></tr>
+      <tr><td>coilLabel</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th><th>Description</th></tr></thead><tbody>
+    
+      <tr><td>coilNumber</td><td>xs:unsignedShort</td><td>1</td><td>Index of this receiver coil.</td></tr>
+      <tr><td>coilName</td><td>xs:string</td><td>1</td><td>Name of this receiver coil.</td></tr>
+    
+  </tbody></table></td><td>0 - 4096
+					</td><td>List of the coils used for this measurement.</td></tr>
+      <tr><td>institutionName</td><td>xs:string</td><td>0 - 1</td><td>Institution where the equipment that produced the Composite Instances is located.</td></tr>
+      <tr><td>stationName</td><td>xs:string</td><td>0 - 1</td><td>User defined name identifying the machine that produced the Composite Instances.</td></tr>
+      <tr><td>deviceID</td><td>xs:string</td><td>0 - 1</td><td>Identifier for the machine that produced the Composite Instances.</td></tr>
+    
+  </tbody></table></td><td>0 - 1</td><td>General information about the acquisition system.</td></tr>
+      <tr><td>experimentalConditions</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th><th>Description</th></tr></thead><tbody>
+    
+      <tr><td>H1resonanceFrequency_Hz</td><td>xs:long</td><td>
+						1
+					</td><td>The resonance frequency in Hz of hydrogen in the static magnetic field of this scanner.</td></tr>
+    
+  </tbody></table></td><td>1</td><td>Information about the experimental conditions.</td></tr>
+      <tr><td>encoding</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th><th>Description</th></tr></thead><tbody>
+    
+      <tr><td>encodedSpace</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th><th>Description</th></tr></thead><tbody>
+    
+      <tr><td>matrixSize</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th></tr></thead><tbody>
+    
+      <tr><td>x</td><td>xs:unsignedShort</td><td>1</td></tr>
+      <tr><td>y</td><td>xs:unsignedShort</td><td>1</td></tr>
+      <tr><td>z</td><td>xs:unsignedShort</td><td>1</td></tr>
+    
+  </tbody></table></td><td>1</td><td>Image extent encoded in k-space in pixels.</td></tr>
+      <tr><td>fieldOfView_mm</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th></tr></thead><tbody>
+    
+      <tr><td>x</td><td>xs:float</td><td>1</td></tr>
+      <tr><td>y</td><td>xs:float</td><td>1</td></tr>
+      <tr><td>z</td><td>xs:float</td><td>1</td></tr>
+    
+  </tbody></table></td><td>1</td><td>Image extent encoded in k-space in mm.</td></tr>
+    
+  </tbody></table></td><td>1</td><td>Description of the image extent in k-space.</td></tr>
+      <tr><td>reconSpace</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th><th>Description</th></tr></thead><tbody>
+    
+      <tr><td>matrixSize</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th></tr></thead><tbody>
+    
+      <tr><td>x</td><td>xs:unsignedShort</td><td>1</td></tr>
+      <tr><td>y</td><td>xs:unsignedShort</td><td>1</td></tr>
+      <tr><td>z</td><td>xs:unsignedShort</td><td>1</td></tr>
+    
+  </tbody></table></td><td>1</td><td>Image extent encoded in k-space in pixels.</td></tr>
+      <tr><td>fieldOfView_mm</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th></tr></thead><tbody>
+    
+      <tr><td>x</td><td>xs:float</td><td>1</td></tr>
+      <tr><td>y</td><td>xs:float</td><td>1</td></tr>
+      <tr><td>z</td><td>xs:float</td><td>1</td></tr>
+    
+  </tbody></table></td><td>1</td><td>Image extent encoded in k-space in mm.</td></tr>
+    
+  </tbody></table></td><td>1</td><td>Description of the image extent after reconstruction.</td></tr>
+      <tr><td>encodingLimits</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th><th>Description</th></tr></thead><tbody>
+    
+      <tr><td>kspace_encoding_step_0</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th></tr></thead><tbody>
+    
+      <tr><td>minimum</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+      <tr><td>maximum</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+      <tr><td>center</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+    
+  </tbody></table></td><td>0 - 1</td><td>Kspace_encoding_step_0 loop counter limits.</td></tr>
+      <tr><td>kspace_encoding_step_1</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th></tr></thead><tbody>
+    
+      <tr><td>minimum</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+      <tr><td>maximum</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+      <tr><td>center</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+    
+  </tbody></table></td><td>0 - 1</td><td>Kspace_encoding_step_1 loop counter limits.</td></tr>
+      <tr><td>kspace_encoding_step_2</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th></tr></thead><tbody>
+    
+      <tr><td>minimum</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+      <tr><td>maximum</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+      <tr><td>center</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+    
+  </tbody></table></td><td>0 - 1</td><td>Kspace_encoding_step_2 loop counter limits.</td></tr>
+      <tr><td>average</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th></tr></thead><tbody>
+    
+      <tr><td>minimum</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+      <tr><td>maximum</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+      <tr><td>center</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+    
+  </tbody></table></td><td>0 - 1</td><td>Average loop counter limits.</td></tr>
+      <tr><td>slice</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th></tr></thead><tbody>
+    
+      <tr><td>minimum</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+      <tr><td>maximum</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+      <tr><td>center</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+    
+  </tbody></table></td><td>0 - 1</td><td>Slice loop counter limits.</td></tr>
+      <tr><td>contrast</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th></tr></thead><tbody>
+    
+      <tr><td>minimum</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+      <tr><td>maximum</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+      <tr><td>center</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+    
+  </tbody></table></td><td>0 - 1</td><td>Contrast loop counter limits.</td></tr>
+      <tr><td>phase</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th></tr></thead><tbody>
+    
+      <tr><td>minimum</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+      <tr><td>maximum</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+      <tr><td>center</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+    
+  </tbody></table></td><td>0 - 1</td><td>Phase loop counter limits.</td></tr>
+      <tr><td>repetition</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th></tr></thead><tbody>
+    
+      <tr><td>minimum</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+      <tr><td>maximum</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+      <tr><td>center</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+    
+  </tbody></table></td><td>0 - 1</td><td>Repetition loop counter limits.</td></tr>
+      <tr><td>set</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th></tr></thead><tbody>
+    
+      <tr><td>minimum</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+      <tr><td>maximum</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+      <tr><td>center</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+    
+  </tbody></table></td><td>0 - 1</td><td>Set loop counter limits.</td></tr>
+      <tr><td>segment</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th></tr></thead><tbody>
+    
+      <tr><td>minimum</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+      <tr><td>maximum</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+      <tr><td>center</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+    
+  </tbody></table></td><td>0 - 1</td><td>Segment loop counter limits.</td></tr>
+    
+  </tbody></table></td><td>1</td><td>Information about the limit values of the loop counters along the encoded dimensions.</td></tr>
+      <tr><td>trajectory</td><td>xs:string</td><td>1</td><td>Enum describing the type of this trajectory.
+      Enumeration is: <br/>cartesian<br/>epi<br/>radial<br/>goldenangle<br/>spiral<br/>other</td></tr>
+      <tr><td>trajectoryDescription</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th><th>Description</th></tr></thead><tbody>
+    
+      <tr><td>identifier</td><td>xs:string</td><td>1</td><td>Human readable type of trajectory e.g. Cartesian, Spiral, Radial.</td></tr>
+      <tr><td>userParameterLong</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th></tr></thead><tbody>
+    
+      <tr><td>name</td><td>xs:string</td><td>
+						1
+					</td></tr>
+      <tr><td>value</td><td>xs:long</td><td>
+						1
+					</td></tr>
+    
+  </tbody></table></td><td>0 - 4096
+					</td><td>Space to describe a trajectory with a number of long integers.</td></tr>
+      <tr><td>userParameterDouble</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th></tr></thead><tbody>
+    
+      <tr><td>name</td><td>xs:string</td><td>
+						1
+					</td></tr>
+      <tr><td>value</td><td>xs:double</td><td>
+						1
+					</td></tr>
+    
+  </tbody></table></td><td>0 - 4096
+					</td><td>Space to describe a trajectory with a number of double precision floats.</td></tr>
+      <tr><td>comment</td><td>xs:string</td><td>0 - 1</td><td>User defined comment on this trajectory.</td></tr>
+    
+  </tbody></table></td><td>0 - 1</td><td>Description of the k-space trajectory used in this measurement.</td></tr>
+      <tr><td>parallelImaging</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th><th>Description</th></tr></thead><tbody>
+    
+      <tr><td>accelerationFactor</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th></tr></thead><tbody>
+    
+      <tr><td>kspace_encoding_step_1</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+      <tr><td>kspace_encoding_step_2</td><td>xs:unsignedShort</td><td>
+						1
+					</td></tr>
+    
+  </tbody></table></td><td>
+						1
+					</td><td>The factor of undersampling applied in two encoding directions.</td></tr>
+      <tr><td>calibrationMode</td><td>xs:string</td><td>0 - 1</td><td>Enum describing which scheme was used to acquire calibration data.
+      Enumeration is: <br/>embedded<br/>interleaved<br/>separate<br/>external<br/>other</td></tr>
+      <tr><td>interleavingDimension</td><td>xs:string</td><td>0 - 1</td><td>Dimension of varying parallel acquisition.
+      Enumeration is: <br/>phase<br/>repetition<br/>contrast<br/>average<br/>other</td></tr>
+    
+  </tbody></table></td><td>0 - 1</td><td>Parameters specific to parallel imaging techniques.</td></tr>
+      <tr><td>echoTrainLength</td><td>xs:long</td><td>0 - 1</td><td>Number of lines in k-space acquired per excitation of the same volume regardless of the type of echo or the number of frames derived from them.</td></tr>
+    
+  </tbody></table></td><td>1 - 4096
+					</td><td>Information how the measured data is layed out in k-space.</td></tr>
+      <tr><td>sequenceParameters</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th><th>Description</th></tr></thead><tbody>
+    
+      <tr><td>TR</td><td>xs:float</td><td>0 - 4096
+					</td><td>The period of time in msec between the beginning of a pulse sequence and the beginning of the succeeding (essentially identical) pulse sequence.</td></tr>
+      <tr><td>TE</td><td>xs:float</td><td>0 - 4096
+					</td><td>Time in ms between the middle of the excitation pulse and the peak of the echo produced (kx=0). In the case of segmented k-space, the TE(eff) is the time between the middle of the excitation pulse to the peak of the echo that is used to cover the center of k-space (i.e., -kx=0, ky=0).</td></tr>
+      <tr><td>TI</td><td>xs:float</td><td>0 - 4096
+					</td><td>Time in msec after the middle of inverting RF pulse to middle of excitation pulse to detect the amount of longitudinal magnetization. Required if Scanning Sequence (0018,0020) has values of IR.</td></tr>
+      <tr><td>flipAngle_deg</td><td>xs:float</td><td>0 - 4096
+					</td><td>Steady state angle in degrees to which the magnetic vector is flipped from the magnetic vector of the primary field.</td></tr>
+      <tr><td>sequence_type</td><td>xs:string</td><td>0 - 1</td><td>Brief human readable description of the sequence type.</td></tr>
+      <tr><td>echo_spacing</td><td>xs:float</td><td>0 - 4096
+					</td><td>Time between excitation RF pulses, which in turn defines the time between echos.</td></tr>
+
+    
+  </tbody></table></td><td>0 - 1</td><td>Parameters describing the acquisition sequence.</td></tr>
+      <tr><td>userParameters</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th><th>Description</th></tr></thead><tbody>
+    
+      <tr><td>userParameterLong</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th></tr></thead><tbody>
+    
+      <tr><td>name</td><td>xs:string</td><td>
+						1
+					</td></tr>
+      <tr><td>value</td><td>xs:long</td><td>
+						1
+					</td></tr>
+    
+  </tbody></table></td><td>0 - 4096
+					</td><td>Space to describe additional values with a number of long integers.</td></tr>
+      <tr><td>userParameterDouble</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th></tr></thead><tbody>
+    
+      <tr><td>name</td><td>xs:string</td><td>
+						1
+					</td></tr>
+      <tr><td>value</td><td>xs:double</td><td>
+						1
+					</td></tr>
+    
+  </tbody></table></td><td>0 - 4096
+					</td><td>Space to describe additional values with a number of double precision floats.</td></tr>
+      <tr><td>userParameterString</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th></tr></thead><tbody>
+    
+      <tr><td>name</td><td>xs:string</td><td>
+						1
+					</td></tr>
+      <tr><td>value</td><td>xs:string</td><td>
+						1
+					</td></tr>
+    
+  </tbody></table></td><td>0 - 4096
+					</td><td>Space to describe additional values with a number of strings.</td></tr>
+      <tr><td>userParameterBase64</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th></tr></thead><tbody>
+    
+      <tr><td>name</td><td>xs:string</td><td>
+						1
+					</td></tr>
+      <tr><td>value</td><td>xs:base64Binary</td><td>
+						1
+					</td></tr>
+    
+  </tbody></table></td><td>0 - 4096
+					</td><td>Space to describe additional values as base64 encoded binary blob.</td></tr>
+    
+  </tbody></table></td><td>0 - 1</td><td>Space to describe additional user defined parameters.</td></tr>
+      <tr><td>waveformInformation</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th><th>Description</th></tr></thead><tbody>
+    
+      <tr><td>waveformName</td><td>xs:string</td><td>
+						1
+					</td><td>Name of an instance of waveform information.</td></tr>
+      <tr><td>waveformType</td><td>xs:string</td><td>
+						1
+					</td><td>Enum describing the type of waveform. 
+      Enumeration is: <br/>ecg<br/>pulse<br/>respiratory<br/>trigger<br/>gradientwaveform<br/>other</td></tr>
+      <tr><td>userParameters</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th><th>Description</th></tr></thead><tbody>
+    
+      <tr><td>userParameterLong</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th></tr></thead><tbody>
+    
+      <tr><td>name</td><td>xs:string</td><td>
+						1
+					</td></tr>
+      <tr><td>value</td><td>xs:long</td><td>
+						1
+					</td></tr>
+    
+  </tbody></table></td><td>0 - 4096
+					</td><td>Space to describe additional values with a number of long integers.</td></tr>
+      <tr><td>userParameterDouble</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th></tr></thead><tbody>
+    
+      <tr><td>name</td><td>xs:string</td><td>
+						1
+					</td></tr>
+      <tr><td>value</td><td>xs:double</td><td>
+						1
+					</td></tr>
+    
+  </tbody></table></td><td>0 - 4096
+					</td><td>Space to describe additional values with a number of double precision floats.</td></tr>
+      <tr><td>userParameterString</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th></tr></thead><tbody>
+    
+      <tr><td>name</td><td>xs:string</td><td>
+						1
+					</td></tr>
+      <tr><td>value</td><td>xs:string</td><td>
+						1
+					</td></tr>
+    
+  </tbody></table></td><td>0 - 4096
+					</td><td>Space to describe additional values with a number of strings.</td></tr>
+      <tr><td>userParameterBase64</td><td><table><thead><tr><th>Name</th><th>Type</th><th>Multiplicity</th></tr></thead><tbody>
+    
+      <tr><td>name</td><td>xs:string</td><td>
+						1
+					</td></tr>
+      <tr><td>value</td><td>xs:base64Binary</td><td>
+						1
+					</td></tr>
+    
+  </tbody></table></td><td>0 - 4096
+					</td><td>Space to describe additional values as base64 encoded binary blob.</td></tr>
+    
+  </tbody></table></td><td>
+						1
+					</td><td>Space to describe the actual data of the Waveforms.</td></tr>
+    
+  </tbody></table></td><td>0 - 32</td><td>Additional waveform data.</td></tr>
+    
+  </tbody></table></body></div></foreignObject></svg>

--- a/doc/schema.md
+++ b/doc/schema.md
@@ -1,0 +1,2 @@
+# Table displaying the structure of the flexible header.
+![](./current_schema_documentation.svg)

--- a/schema/ismrmrd.xsd
+++ b/schema/ismrmrd.xsd
@@ -5,26 +5,85 @@
 
   <xs:complexType name="ismrmrdHeader">
     <xs:sequence>
-      <xs:element maxOccurs="1" minOccurs="0" name="version" type="xs:long" />
-      <xs:element maxOccurs="1" minOccurs="0" name="subjectInformation" type="subjectInformationType" />
-      <xs:element maxOccurs="1" minOccurs="0" name="studyInformation" type="studyInformationType" />
-      <xs:element maxOccurs="1" minOccurs="0" name="measurementInformation" type="measurementInformationType" />
-      <xs:element maxOccurs="1" minOccurs="0" name="acquisitionSystemInformation" type="acquisitionSystemInformationType" />
-      <xs:element maxOccurs="1" minOccurs="1" name="experimentalConditions" type="experimentalConditionsType" />
-      <xs:element maxOccurs="unbounded" minOccurs="1" name="encoding" type="encodingType" />
-      <xs:element maxOccurs="1" minOccurs="0" name="sequenceParameters" type="sequenceParametersType" />
-      <xs:element maxOccurs="1" minOccurs="0" name="userParameters" type="userParametersType" />
-      <xs:element maxOccurs="32" minOccurs="0" name="waveformInformation" type="waveformInformationType" />
+      <xs:element maxOccurs="1" minOccurs="0" name="version" type="xs:long">
+	  	<xs:annotation>
+			<xs:documentation xml:lang="en">Major version of ISMRMRD.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="0" name="subjectInformation" type="subjectInformationType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Information about the scanned patient.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="0" name="studyInformation" type="studyInformationType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Information about the study for which this data was acquired if any.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+	  <xs:element maxOccurs="1" minOccurs="0" name="measurementInformation" type="measurementInformationType">
+	  		<xs:annotation>
+			<xs:documentation xml:lang="en">General information about this measurement and its relation to other measurements.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="0" name="acquisitionSystemInformation" type="acquisitionSystemInformationType">
+	  		<xs:annotation>
+			<xs:documentation xml:lang="en">General information about the acquisition system.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="1" name="experimentalConditions" type="experimentalConditionsType">
+	  		<xs:annotation>
+			<xs:documentation xml:lang="en">Information about the experimental conditions.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="unbounded" minOccurs="1" name="encoding" type="encodingType">
+	  		<xs:annotation>
+			<xs:documentation xml:lang="en">Information how the measured data is layed out in k-space.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="0" name="sequenceParameters" type="sequenceParametersType">
+	  		<xs:annotation>
+			<xs:documentation xml:lang="en">Parameters describing the acquisition sequence.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="0" name="userParameters" type="userParametersType">
+	  		<xs:annotation>
+			<xs:documentation xml:lang="en">Space to describe additional user defined parameters.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="32" minOccurs="0" name="waveformInformation" type="waveformInformationType">
+	  	<xs:annotation>
+			<xs:documentation xml:lang="en">Additional waveform data.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
     </xs:sequence>
   </xs:complexType>
 
   <xs:complexType name="subjectInformationType">
     <xs:all>
-      <xs:element minOccurs="0" name="patientName" type="xs:string" />
-      <xs:element minOccurs="0" name="patientWeight_kg" type="xs:float" />
-      <xs:element minOccurs="0" name="patientID" type="xs:string" />
-      <xs:element minOccurs="0" name="patientBirthdate" type="xs:date" />
+      <xs:element minOccurs="0" name="patientName" type="xs:string">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Patient's full name.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" name="patientWeight_kg" type="xs:float">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Patient's weight in kg.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" name="patientID" type="xs:string">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Primary identifier for the Patient.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" name="patientBirthdate" type="xs:date">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Birth date of the Patient. YYYY-MM-DD.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
       <xs:element minOccurs="0" name="patientGender">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Gender of the named Patient.</xs:documentation>
+		</xs:annotation>
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:pattern value="[MFO]" />
@@ -36,13 +95,41 @@
 
   <xs:complexType name="studyInformationType">
     <xs:all>
-      <xs:element minOccurs="0" maxOccurs="1" name="studyDate" type="xs:date" />
-      <xs:element minOccurs="0" maxOccurs="1" name="studyTime" type="xs:time" />
-      <xs:element minOccurs="0" maxOccurs="1" name="studyID" type="xs:string" />
-      <xs:element minOccurs="0" maxOccurs="1" name="accessionNumber" type="xs:long" />
-      <xs:element minOccurs="0" maxOccurs="1" name="referringPhysicianName" type="xs:string" />
-      <xs:element minOccurs="0" maxOccurs="1" name="studyDescription" type="xs:string" />
-      <xs:element minOccurs="0" maxOccurs="1" name="studyInstanceUID" type="xs:string" />
+      <xs:element minOccurs="0" maxOccurs="1" name="studyDate" type="xs:date">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Date the Study started.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" maxOccurs="1" name="studyTime" type="xs:time">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Time the Study started.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" maxOccurs="1" name="studyID" type="xs:string">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">User or equipment-generated Study identifier.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" maxOccurs="1" name="accessionNumber" type="xs:long">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">A RIS generated number that identifies the order for the Study.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" maxOccurs="1" name="referringPhysicianName" type="xs:string">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Name of the Patient's referring physician</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" maxOccurs="1" name="studyDescription" type="xs:string">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Institution-generated description or classification of the Study (component) performed.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" maxOccurs="1" name="studyInstanceUID" type="xs:string">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Unique identifier for the Study.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
     </xs:all>
   </xs:complexType>
 
@@ -61,70 +148,206 @@
 
   <xs:complexType name="measurementInformationType">
     <xs:sequence>
-      <xs:element minOccurs="0" name="measurementID" type="xs:string" />
-      <xs:element minOccurs="0" name="seriesDate" type="xs:date" />
-      <xs:element minOccurs="0" name="seriesTime" type="xs:time" />
-      <xs:element minOccurs="1" name="patientPosition" type="patientPositionType" />
-      <xs:element minOccurs="0" name="initialSeriesNumber" type="xs:long" />
-      <xs:element minOccurs="0" name="protocolName" type="xs:string" />
-      <xs:element minOccurs="0" name="seriesDescription" type="xs:string" />
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="measurementDependency" type="measurementDependencyType" />
-      <xs:element minOccurs="0" name="seriesInstanceUIDRoot" type="xs:string" />
-      <xs:element minOccurs="0" name="frameOfReferenceUID" type="xs:string" />
-      <xs:element minOccurs="0" name="referencedImageSequence" type="referencedImageSequenceType" />
+      <xs:element minOccurs="0" name="measurementID" type="xs:string">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Unique identifier of the measurement.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" name="seriesDate" type="xs:date">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Date the Series started.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" name="seriesTime" type="xs:time">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Time the Series started.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="1" name="patientPosition" type="patientPositionType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Patient position descriptor relative to the equipment.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" name="initialSeriesNumber" type="xs:long">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Next available series number in the study.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" name="protocolName" type="xs:string">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">User-defined description of the conditions under which the Series was performed.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" name="seriesDescription" type="xs:string">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Description of the Series.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="measurementDependency" type="measurementDependencyType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Identification of measurement related to this measurement. One or more Items are permitted in this Sequence.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" name="seriesInstanceUIDRoot" type="xs:string">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">First portion of the series unique identifier.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" name="frameOfReferenceUID" type="xs:string">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Unique identifier for the frame of reference the data was collected in. Data with the same frame of reference can be combined.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" name="referencedImageSequence" type="referencedImageSequenceType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Other images significantly related to this image.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
     </xs:sequence>
   </xs:complexType>
 
   <xs:complexType name="measurementDependencyType">
     <xs:sequence>
-      <xs:element maxOccurs="1" minOccurs="1" name="dependencyType" type="xs:string" />
-      <xs:element maxOccurs="1" minOccurs="1" name="measurementID" type="xs:string" />
+      <xs:element maxOccurs="1" minOccurs="1" name="dependencyType" type="xs:string">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Describes the purpose for which the reference is made. E.g. "Noise".</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="1" name="measurementID" type="xs:string">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Unique identifier of dependent measurement.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
     </xs:sequence>
   </xs:complexType>
 
   <xs:complexType name="coilLabelType">
     <xs:sequence>
-      <xs:element maxOccurs="1" minOccurs="1" name="coilNumber" type="xs:unsignedShort" />
-      <xs:element maxOccurs="1" minOccurs="1" name="coilName" type="xs:string" />
+      <xs:element maxOccurs="1" minOccurs="1" name="coilNumber" type="xs:unsignedShort">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Index of this receiver coil.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="1" name="coilName" type="xs:string">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Name of this receiver coil.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
     </xs:sequence>
   </xs:complexType>
 
   <xs:complexType name="acquisitionSystemInformationType">
     <xs:sequence>
-      <xs:element minOccurs="0" maxOccurs="1" name="systemVendor" type="xs:string" />
-      <xs:element minOccurs="0" maxOccurs="1" name="systemModel" type="xs:string" />
-      <xs:element minOccurs="0" maxOccurs="1" name="systemFieldStrength_T" type="xs:float" />
-      <xs:element minOccurs="0" maxOccurs="1" name="relativeReceiverNoiseBandwidth" type="xs:float" />
-      <xs:element minOccurs="0" maxOccurs="1" name="receiverChannels" type="xs:unsignedShort" />
-      <xs:element minOccurs="0" maxOccurs="unbounded" name="coilLabel" type="coilLabelType" />
-      <xs:element minOccurs="0" maxOccurs="1" name="institutionName" type="xs:string" />
-      <xs:element minOccurs="0" maxOccurs="1" name="stationName" type="xs:string" />
-      <xs:element minOccurs="0" maxOccurs="1" name="deviceID" type="xs:string" />
+      <xs:element minOccurs="0" maxOccurs="1" name="systemVendor" type="xs:string">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Manufacturer of the device.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" maxOccurs="1" name="systemModel" type="xs:string">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Manufacturer's model name of the device.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" maxOccurs="1" name="systemFieldStrength_T" type="xs:float">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Fieldstrength of the device in Tesla.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" maxOccurs="1" name="relativeReceiverNoiseBandwidth" type="xs:float">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Effective bandwidth of noise measurement data as fraction.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" maxOccurs="1" name="receiverChannels" type="xs:unsignedShort">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Count of coils used for this measurement.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" maxOccurs="unbounded" name="coilLabel" type="coilLabelType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">List of the coils used for this measurement.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" maxOccurs="1" name="institutionName" type="xs:string">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Institution where the equipment that produced the Composite Instances is located.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" maxOccurs="1" name="stationName" type="xs:string">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">User defined name identifying the machine that produced the Composite Instances.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" maxOccurs="1" name="deviceID" type="xs:string">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Identifier for the machine that produced the Composite Instances.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
     </xs:sequence>
   </xs:complexType>
 
   <xs:complexType name="experimentalConditionsType">
     <xs:all>
-      <xs:element name="H1resonanceFrequency_Hz" type="xs:long" />
+      <xs:element name="H1resonanceFrequency_Hz" type="xs:long">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">The resonance frequency in Hz of hydrogen in the static magnetic field of this scanner.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
     </xs:all>
   </xs:complexType>
 
   <xs:complexType name="encodingType">
     <xs:all>
-      <xs:element maxOccurs="1" minOccurs="1" name="encodedSpace" type="encodingSpaceType" />
-      <xs:element maxOccurs="1" minOccurs="1" name="reconSpace" type="encodingSpaceType" />
-      <xs:element maxOccurs="1" minOccurs="1" name="encodingLimits" type="encodingLimitsType" />
-      <xs:element maxOccurs="1" minOccurs="1" name="trajectory" type="trajectoryType" />
-      <xs:element maxOccurs="1" minOccurs="0" name="trajectoryDescription" type="trajectoryDescriptionType" />
-      <xs:element maxOccurs="1" minOccurs="0" name="parallelImaging" type="parallelImagingType" />
-      <xs:element maxOccurs="1" minOccurs="0" name="echoTrainLength" type="xs:long" />
+      <xs:element maxOccurs="1" minOccurs="1" name="encodedSpace" type="encodingSpaceType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Description of the image extent in k-space.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="1" name="reconSpace" type="encodingSpaceType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Description of the image extent after reconstruction.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="1" name="encodingLimits" type="encodingLimitsType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Information about the limit values of the loop counters along the encoded dimensions.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="1" name="trajectory" type="trajectoryType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Enum describing the type of this trajectory.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="0" name="trajectoryDescription" type="trajectoryDescriptionType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Description of the k-space trajectory used in this measurement.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="0" name="parallelImaging" type="parallelImagingType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Parameters specific to parallel imaging techniques.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="0" name="echoTrainLength" type="xs:long">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Number of lines in k-space acquired per excitation of the same volume regardless of the type of echo or the number of frames derived from them.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
     </xs:all>
   </xs:complexType>
 
   <xs:complexType name="encodingSpaceType">
     <xs:all>
-      <xs:element maxOccurs="1" minOccurs="1" name="matrixSize" type="matrixSizeType" />
-      <xs:element maxOccurs="1" minOccurs="1" name="fieldOfView_mm" type="fieldOfView_mm" />
+      <xs:element maxOccurs="1" minOccurs="1" name="matrixSize" type="matrixSizeType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Image extent encoded in k-space in pixels.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="1" name="fieldOfView_mm" type="fieldOfView_mm">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Image extent encoded in k-space in mm.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
     </xs:all>
   </xs:complexType>
 
@@ -154,16 +377,56 @@
 
   <xs:complexType name="encodingLimitsType">
     <xs:all>
-      <xs:element maxOccurs="1" minOccurs="0" name="kspace_encoding_step_0" type="limitType" />
-      <xs:element maxOccurs="1" minOccurs="0" name="kspace_encoding_step_1" type="limitType" />
-      <xs:element maxOccurs="1" minOccurs="0" name="kspace_encoding_step_2" type="limitType" />
-      <xs:element maxOccurs="1" minOccurs="0" name="average" type="limitType" />
-      <xs:element maxOccurs="1" minOccurs="0" name="slice" type="limitType" />
-      <xs:element maxOccurs="1" minOccurs="0" name="contrast" type="limitType" />
-      <xs:element maxOccurs="1" minOccurs="0" name="phase" type="limitType" />
-      <xs:element maxOccurs="1" minOccurs="0" name="repetition" type="limitType" />
-      <xs:element maxOccurs="1" minOccurs="0" name="set" type="limitType" />
-      <xs:element maxOccurs="1" minOccurs="0" name="segment" type="limitType" />
+      <xs:element maxOccurs="1" minOccurs="0" name="kspace_encoding_step_0" type="limitType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Kspace_encoding_step_0 loop counter limits.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="0" name="kspace_encoding_step_1" type="limitType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Kspace_encoding_step_1 loop counter limits.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="0" name="kspace_encoding_step_2" type="limitType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Kspace_encoding_step_2 loop counter limits.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="0" name="average" type="limitType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Average loop counter limits.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="0" name="slice" type="limitType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Slice loop counter limits.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="0" name="contrast" type="limitType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Contrast loop counter limits.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="0" name="phase" type="limitType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Phase loop counter limits.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="0" name="repetition" type="limitType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Repetition loop counter limits.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="0" name="set" type="limitType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Set loop counter limits.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="0" name="segment" type="limitType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Segment loop counter limits.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
     </xs:all>
   </xs:complexType>
 
@@ -180,21 +443,61 @@
 
   <xs:complexType name="trajectoryDescriptionType">
     <xs:sequence>
-      <xs:element maxOccurs="1" minOccurs="1" name="identifier" type="xs:string" />
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="userParameterLong" type="userParameterLongType" />
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="userParameterDouble" type="userParameterDoubleType" />
-      <xs:element maxOccurs="1" minOccurs="0" name="comment" type="xs:string" />
+      <xs:element maxOccurs="1" minOccurs="1" name="identifier" type="xs:string">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Human readable type of trajectory e.g. Cartesian, Spiral, Radial.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="userParameterLong" type="userParameterLongType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Space to describe a trajectory with a number of long integers.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="userParameterDouble" type="userParameterDoubleType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Space to describe a trajectory with a number of double precision floats.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="0" name="comment" type="xs:string">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">User defined comment on this trajectory.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
     </xs:sequence>
   </xs:complexType>
 
   <xs:complexType name="sequenceParametersType">
     <xs:sequence>
-      <xs:element minOccurs="0" maxOccurs="unbounded" type="xs:float" name="TR" />
-      <xs:element minOccurs="0" maxOccurs="unbounded" type="xs:float" name="TE" />
-      <xs:element minOccurs="0" maxOccurs="unbounded" type="xs:float" name="TI" />
-      <xs:element minOccurs="0" maxOccurs="unbounded" type="xs:float" name="flipAngle_deg" />
-      <xs:element minOccurs="0" maxOccurs="1" type="xs:string" name="sequence_type" />
-      <xs:element minOccurs="0" maxOccurs="unbounded" type="xs:float" name="echo_spacing" />
+      <xs:element minOccurs="0" maxOccurs="unbounded" type="xs:float" name="TR">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">The period of time in msec between the beginning of a pulse sequence and the beginning of the succeeding (essentially identical) pulse sequence.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" maxOccurs="unbounded" type="xs:float" name="TE">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Time in ms between the middle of the excitation pulse and the peak of the echo produced (kx=0). In the case of segmented k-space, the TE(eff) is the time between the middle of the excitation pulse to the peak of the echo that is used to cover the center of k-space (i.e., -kx=0, ky=0).</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" maxOccurs="unbounded" type="xs:float" name="TI">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Time in msec after the middle of inverting RF pulse to middle of excitation pulse to detect the amount of longitudinal magnetization. Required if Scanning Sequence (0018,0020) has values of IR.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" maxOccurs="unbounded" type="xs:float" name="flipAngle_deg">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Steady state angle in degrees to which the magnetic vector is flipped from the magnetic vector of the primary field.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" maxOccurs="1" type="xs:string" name="sequence_type">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Brief human readable description of the sequence type.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element minOccurs="0" maxOccurs="unbounded" type="xs:float" name="echo_spacing">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Time between excitation RF pulses, which in turn defines the time between echos.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
 
     </xs:sequence>
   </xs:complexType>
@@ -229,16 +532,36 @@
 
   <xs:complexType name="referencedImageSequenceType">
     <xs:sequence>
-      <xs:element minOccurs="0" maxOccurs="unbounded" name="referencedSOPInstanceUID" type="xs:string" />
+      <xs:element minOccurs="0" maxOccurs="unbounded" name="referencedSOPInstanceUID" type="xs:string">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Uniquely identifies the referenced SOP Instance.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
     </xs:sequence>
   </xs:complexType>
 
   <xs:complexType name="userParametersType">
     <xs:sequence>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="userParameterLong" type="userParameterLongType" />
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="userParameterDouble" type="userParameterDoubleType" />
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="userParameterString" type="userParameterStringType" />
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="userParameterBase64" type="userParameterBase64Type" />
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="userParameterLong" type="userParameterLongType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Space to describe additional values with a number of long integers.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="userParameterDouble" type="userParameterDoubleType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Space to describe additional values with a number of double precision floats.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="userParameterString" type="userParameterStringType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Space to describe additional values with a number of strings.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="userParameterBase64" type="userParameterBase64Type">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Space to describe additional values as base64 encoded binary blob.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
     </xs:sequence>
   </xs:complexType>
 
@@ -271,17 +594,36 @@
 
   <xs:complexType name="parallelImagingType">
     <xs:sequence>
-      <xs:element type="accelerationFactorType" name="accelerationFactor" />
-      <xs:element maxOccurs="1" minOccurs="0" type="calibrationModeType" name="calibrationMode" />
-      <xs:element maxOccurs="1" minOccurs="0" type="interleavingDimensionType" name="interleavingDimension" />
+      <xs:element type="accelerationFactorType" name="accelerationFactor">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">The factor of undersampling applied in two encoding directions.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="0" type="calibrationModeType" name="calibrationMode">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Enum describing which scheme was used to acquire calibration data.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
+      <xs:element maxOccurs="1" minOccurs="0" type="interleavingDimensionType" name="interleavingDimension">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Dimension of varying parallel acquisition.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
     </xs:sequence>
   </xs:complexType>
 
 
   <xs:complexType name="waveformInformationType">
     <xs:sequence>
-      <xs:element name="waveformName" type="xs:string" />
+      <xs:element name="waveformName" type="xs:string">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Name of an instance of waveform information.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
       <xs:element name="waveformType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Enum describing the type of waveform. </xs:documentation>
+		</xs:annotation>
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:enumeration value="ecg" />
@@ -293,7 +635,11 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="userParameters" type="userParametersType" />
+      <xs:element name="userParameters" type="userParametersType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Space to describe the actual data of the Waveforms.</xs:documentation>
+		</xs:annotation>
+	  </xs:element>
     </xs:sequence>
   </xs:complexType>
 </xs:schema>


### PR DESCRIPTION
This is my new attempt of adding documentation for the MRD header. The documentation is now added as annotations to the schema itself. I developed a XSLT to create a SVG out of that that depicts the content of the header in a simpler way than reading the schema. 

What is missing from this pull request is some automation to call the XSLT whenever a new commit is performed. Additionally the md file which gets rendered by github is not yet linked anywhere from this repo.