### PR TITLE
Added support for automatic RPM builds

### DIFF
--- a/.github/workflows/rpkg_build.yml
+++ b/.github/workflows/rpkg_build.yml
@@ -1,0 +1,28 @@
+name: RPKG
+
+on:
+  push:
+    branches:
+      - master
+  
+  pull_request:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    container:
+      image: fedora:latest
+    steps:
+    - name: Install dependencies
+      run: sudo dnf install rpkg git dnf-plugins-core -y
+
+    - uses: actions/checkout@v2
+    - name: Run RPKG 
+      run: |
+        cd "$GITHUB_WORKSPACE" 
+        rpkg spec --outdir ./
+        sudo dnf builddep -y ismrmrd.spec
+        rm ismrmrd.spec
+        rpkg local 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,22 +231,21 @@ target_link_libraries(ismrmrd ${ISMRMRD_TARGET_LINK_LIBS})
 list(APPEND ISMRMRD_LIBRARIES ismrmrd) # Add to list of libraries to be found
 list(APPEND ISMRMRD_LIBRARY_DIRS ${CMAKE_BINARY_DIR} ) # Add to list of directories to find libraries
 
+include(GNUInstallDirs)
+
 # install the main library
 install(TARGETS ismrmrd EXPORT ISMRMRDTargets
-   LIBRARY DESTINATION lib
-   ARCHIVE DESTINATION lib
-   RUNTIME DESTINATION bin
+   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} 
    COMPONENT Devel
 )
 
 # install the headers
-install(DIRECTORY include/ismrmrd  DESTINATION include COMPONENT Devel)
+install(DIRECTORY include/ismrmrd  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT Devel)
 
 # install the schema file
 install(FILES schema/ismrmrd.xsd DESTINATION share/ismrmrd/schema COMPONENT Devel)
-
-# install the cmake modules
-install(FILES cmake/FindFFTW3.cmake DESTINATION share/ismrmrd/cmake COMPONENT Devel)
 
 #  ---   Main Library  (end) ----
 
@@ -276,7 +275,7 @@ install(DIRECTORY matlab DESTINATION share/ismrmrd )
 #
 
 include(CMakePackageConfigHelpers)
-set(INSTALL_CONFIGDIR lib/cmake/ISMRMRD)
+set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/ISMRMRD)
 
 set(CONFIG_ISMRMRD_SCHEMA_DIR   ${ISMRMRD_SCHEMA_DIR})
 set(CONFIG_ISMRMRD_TARGET_INCLUDE_DIRS ${ISMRMRD_TARGET_INCLUDE_DIRS})
@@ -331,7 +330,7 @@ install(FILES
   COMPONENT Devel)
 
 export(PACKAGE ISMRMRD)
- 
+
 # Create package
 string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
 include(${ISMRMRD_CMAKE_DIR}/ismrmrd_cpack.cmake)

--- a/ismrmrd.spec.rpkg
+++ b/ismrmrd.spec.rpkg
@@ -1,0 +1,55 @@
+Name:       {{{ git_dir_name }}}
+Version:    {{{ git_dir_version }}}
+Release:    1%{?dist}
+Summary:    Library for working with MRI data in the ISMRMRD format 
+
+License:    MIT
+URL:        https://github.com/ismrmrd/ismrmrd
+VCS:        {{{ git_dir_vcs }}}
+
+Source: {{{ git_dir_pack }}}
+
+BuildRequires: make, cmake, gcc, gcc-c++, pugixml-devel, hdf5-devel, pugixml, hdf5
+
+Requires: pugixml, hdf5
+
+%package devel
+Requires:	%{name}%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+Summary: ismrmrd development files
+
+
+%description
+ The ISMRMRD format combines a mix of flexible data structures (XML header) and fixed structures (equivalent to C-structs) to represent MRI data.
+In addition, the ISMRMRD format also specifies an image header for storing reconstructed images and the accompanying C++ library provides a convenient way of writing such images into HDF5 files along with generic arrays for storing less well defined data structures, e.g. coil sensitivity maps or other calibration data. 
+
+%description devel 
+Header files for the ISMRMRD package 
+
+%prep
+{{{ git_dir_setup_macro }}}
+
+%changelog
+{{{ git_dir_changelog }}}
+
+%build
+%cmake 
+%cmake_build
+
+
+%install
+%cmake_install
+rm -rf %{buildroot}/usr/share/ismrmrd/matlab 
+
+%files
+%license LICENSE
+%{_libdir}/libismrmrd.so*
+%{_bindir}/ismrmrd_*
+
+%files devel 
+%{_includedir}/ismrmrd
+%{_libdir}/libismrmrd.so
+%{_libdir}/cmake/ISMRMRD
+%{_datadir}/ismrmrd/schema/ismrmrd.xsd
+
+%clean
+rm -rf %{buildroot}


### PR DESCRIPTION
This pull request fixes the default install directory and adds a spec file which allows for automatic RPM builds on [copr](copr.fedorainfracloud.org/) (like [this](https://copr.fedorainfracloud.org/coprs/davidchansen/ISMRMRD/)).
