### PR TITLE
Small fix to pipeline

### DIFF
--- a/.github/workflows/ismrmrd_build.yml
+++ b/.github/workflows/ismrmrd_build.yml
@@ -24,6 +24,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        sudo apt-get update
         sudo apt-get -y install doxygen git-core graphviz libboost-all-dev libfftw3-dev libhdf5-serial-dev
 
     - name: Configure CMake


### PR DESCRIPTION
Recently a CI build failed because apt could not retrieve a package. In the pipeline we need a `sudo apt-get update` before installing packages so that the build nodes have an accurate list of packages. 