### PR TITLE
Bumping build number - PugiXML conda break

### DIFF
--- a/.github/workflows/rpkg_build.yml
+++ b/.github/workflows/rpkg_build.yml
@@ -4,14 +4,14 @@ on:
   push:
     branches:
       - master
-
+  
   pull_request:
     branches:
       - master
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    
     container:
       image: fedora:37
     steps:
@@ -19,14 +19,14 @@ jobs:
       run: sudo dnf install rpkg git dnf-plugins-core -y
 
     - uses: actions/checkout@v3
-      with:
+      with: 
         fetch-depth: 0
-    - name: Run RPKG
+    - name: Run RPKG 
       run: |
         git config --global --add safe.directory "*"
         chown -hR root "$GITHUB_WORKSPACE"
-        cd "$GITHUB_WORKSPACE"
+        cd "$GITHUB_WORKSPACE" 
         rpkg spec --outdir ./
         sudo dnf builddep -y ismrmrd.spec
         rm ismrmrd.spec
-        rpkg local
+        rpkg local 

--- a/.github/workflows/rpkg_build.yml
+++ b/.github/workflows/rpkg_build.yml
@@ -4,29 +4,29 @@ on:
   push:
     branches:
       - master
-  
+
   pull_request:
     branches:
       - master
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+
     container:
-      image: fedora:latest
+      image: fedora:37
     steps:
     - name: Install dependencies
       run: sudo dnf install rpkg git dnf-plugins-core -y
 
     - uses: actions/checkout@v3
-      with: 
+      with:
         fetch-depth: 0
-    - name: Run RPKG 
+    - name: Run RPKG
       run: |
         git config --global --add safe.directory "*"
         chown -hR root "$GITHUB_WORKSPACE"
-        cd "$GITHUB_WORKSPACE" 
+        cd "$GITHUB_WORKSPACE"
         rpkg spec --outdir ./
         sudo dnf builddep -y ismrmrd.spec
         rm ismrmrd.spec
-        rpkg local 
+        rpkg local

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -9,6 +9,9 @@ package:
 source:
   path: ../
 
+build:
+  number: 1
+
 requirements:
   build:
     - boost {{ boost }}

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
-myst-parser==0.19.2
-sphinx~=4.3.0
-breathe==4.35.0
-sphinx-rtd-theme==1.2.0
-sphinxcontrib-mermaid==0.8.1
+myst-parser
+sphinx
+breathe
+sphinx-rtd-theme
+sphinxcontrib-mermaid

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
-myst-parser
+myst-parser==0.19.2
 sphinx~=4.3.0
-breathe
-sphinx-rtd-theme
-sphinxcontrib-mermaid
+breathe==4.35.0
+sphinx-rtd-theme==1.2.0
+sphinxcontrib-mermaid==0.8.1

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - mkl-include>=2022.0.0    # dev
   - ninja=1.10.2             # dev
   - numpy=1.22.1             # dev
-  - pugixml=1.11.4           # dev
+  - pugixml=1.11.4
   - pyfftw=0.12.0            # dev
   - python=3.9               # dev
   - scipy=1.7.1              # dev

--- a/include/ismrmrd/xml.h
+++ b/include/ismrmrd/xml.h
@@ -6,17 +6,18 @@
 #ifndef ISMRMRDXML_H
 #define ISMRMRDXML_H
 
-#include "ismrmrd/export.h"
 #include "ismrmrd.h"
+#include "ismrmrd/export.h"
+#include <array>
 #include <cstddef>
-#include <new> //For std::badalloc
+#include <cstdint>
+#include <iostream>
+#include <new>       //For std::badalloc
 #include <stdexcept> //For std::length_error
 #include <stdio.h>
 #include <string.h>
-#include <iostream>
 #include <string>
 #include <vector>
-#include <array>
 
 /**
   TODO LIST
@@ -31,164 +32,157 @@
  * @{
  */
 
-namespace ISMRMRD
-{
+namespace ISMRMRD {
 
-  template <typename T> class Optional
-  {
-  public:
+template <typename T>
+class Optional {
+public:
     Optional()
-      : present_(false)
-    {
-
+        : present_(false) {
     }
 
-    Optional(const T&v) {
-      present_ = true;
-      value_ = v;      
+    Optional(const T &v) {
+        present_ = true;
+        value_ = v;
     }
 
-	Optional& operator=(const Optional& o) {
-		present_ = o.present_;
-		if (present_)
-			value_ = o.value_;	
-		return *this;
-	}
-
-    Optional& operator=(const T& v) {
-      present_ = true;
-      value_ = v;
-      return *this;
+    Optional &operator=(const Optional &o) {
+        present_ = o.present_;
+        if (present_)
+            value_ = o.value_;
+        return *this;
     }
 
-     T* operator->() {
-      return &value_;
+    Optional &operator=(const T &v) {
+        present_ = true;
+        value_ = v;
+        return *this;
     }
 
-    T& operator*() {
-      return value_;
+    T *operator->() {
+        return &value_;
     }
 
-    const T* operator->() const {
-      return &value_;
+    T &operator*() {
+        return value_;
     }
 
-    const T& operator*() const {
-      return value_;
+    const T *operator->() const {
+        return &value_;
+    }
+
+    const T &operator*() const {
+        return value_;
     }
 
     operator bool() const {
-      return present_;
+        return present_;
     }
 
     bool is_present() const {
-      return present_;
+        return present_;
     }
 
     bool has_value() const noexcept {
         return present_;
     }
 
-
-  T &value() &{
-      if (!present_) {
-          throw std::runtime_error("Access optional value, which has not been set");
-      }
-      return value_;
-  }
-
-
-  const T &value() const &{
-      if (!present_) {
-          throw std::runtime_error("Access optional value, which has not been set");
-      }
-      return value_;
-  }
-
-  T &&value() &&{
-      if (!present_) {
-          throw std::runtime_error("Access optional value, which has not been set");
-      }
-      return std::move(value_);
-  }
-
-  const T &&value() const &&{
-      if (!present_) {
-          throw std::runtime_error("Access optional value, which has not been set");
-      }
-      return std::move(value_);
-  }
-
-  T &get() & {
-      return  this->value();
+    T &value() & {
+        if (!present_) {
+            throw std::runtime_error("Access optional value, which has not been set");
+        }
+        return value_;
     }
 
-    T&& get()&&{
+    const T &value() const & {
+        if (!present_) {
+            throw std::runtime_error("Access optional value, which has not been set");
+        }
+        return value_;
+    }
+
+    T &&value() && {
+        if (!present_) {
+            throw std::runtime_error("Access optional value, which has not been set");
+        }
+        return std::move(value_);
+    }
+
+    const T &&value() const && {
+        if (!present_) {
+            throw std::runtime_error("Access optional value, which has not been set");
+        }
+        return std::move(value_);
+    }
+
+    T &get() & {
         return this->value();
     }
-     const T &get() const &  {
-          return  this->value();
-      }
 
-     const  T&& get() const &&{
-          return this->value();
-      }
-  template<class U>
-  T value_or(U &&default_value) const &{
-      return bool(*this) ? **this : static_cast<T>(std::forward<U>(default_value));
-  }
-
-  template<class U>
-  T value_or(U &&default_value) &&{
-      return bool(*this) ? std::move(**this) : static_cast<T>(std::forward<U>(default_value));
-  }
-
-    bool operator==(const Optional<T>& other) const {
-      if (this->present_ && other.present_) return this->get() == *other;
-      if ((!this->present_) && (!other.present_)) return true;
-      return false;
+    T &&get() && {
+        return this->value();
+    }
+    const T &get() const & {
+        return this->value();
     }
 
-    bool operator==(const T& val) const {
-      if (this->present_) return this->get() == val;
-      return false; 
+    const T &&get() const && {
+        return this->value();
+    }
+    template <class U>
+    T value_or(U &&default_value) const & {
+        return bool(*this) ? **this : static_cast<T>(std::forward<U>(default_value));
     }
 
-
-  T& operator()() {
-  return value();
-}
-
-    void set(const T& v) {
-      present_ = true;
-      value_ = v;
+    template <class U>
+    T value_or(U &&default_value) && {
+        return bool(*this) ? std::move(**this) : static_cast<T>(std::forward<U>(default_value));
     }
 
-  protected:
+    bool operator==(const Optional<T> &other) const {
+        if (this->present_ && other.present_)
+            return this->get() == *other;
+        if ((!this->present_) && (!other.present_))
+            return true;
+        return false;
+    }
+
+    bool operator==(const T &val) const {
+        if (this->present_)
+            return this->get() == val;
+        return false;
+    }
+
+    T &operator()() {
+        return value();
+    }
+
+    void set(const T &v) {
+        present_ = true;
+        value_ = v;
+    }
+
+protected:
     bool present_;
     T value_;
+};
 
-  }; 
-
-  struct threeDimensionalFloat
-  {
+struct threeDimensionalFloat {
     float x;
     float y;
     float z;
-  };
+};
 
-  struct SubjectInformation 
-  {
+struct SubjectInformation {
     Optional<std::string> patientName;
     Optional<float> patientWeight_kg;
     Optional<float> patientHeight_m;
     Optional<std::string> patientID;
     Optional<std::string> patientBirthdate;
     Optional<std::string> patientGender;
-  };
+};
 
-  struct StudyInformation
-  {
+struct StudyInformation {
 
     Optional<std::string> studyDate;
     Optional<std::string> studyTime;
@@ -198,22 +192,19 @@ namespace ISMRMRD
     Optional<std::string> studyDescription;
     Optional<std::string> studyInstanceUID;
     Optional<std::string> bodyPartExamined;
-  };
+};
 
-  struct MeasurementDependency
-  {
+struct MeasurementDependency {
 
-      std::string dependencyType;
+    std::string dependencyType;
     std::string measurementID;
-  };
+};
 
-  struct ReferencedImageSequence
-  {
-      std::string referencedSOPInstanceUID;
-  };
-  
-  struct MeasurementInformation
-  {
+struct ReferencedImageSequence {
+    std::string referencedSOPInstanceUID;
+};
+
+struct MeasurementInformation {
     Optional<std::string> measurementID;
     Optional<std::string> seriesDate;
     Optional<std::string> seriesTime;
@@ -227,16 +218,14 @@ namespace ISMRMRD
     Optional<std::string> seriesInstanceUIDRoot;
     Optional<std::string> frameOfReferenceUID;
     std::vector<ReferencedImageSequence> referencedImageSequence;
-  };
+};
 
-  struct CoilLabel
-  {
+struct CoilLabel {
     std::uint16_t coilNumber;
     std::string coilName;
-  };
-  
-  struct AcquisitionSystemInformation
-  {
+};
+
+struct AcquisitionSystemInformation {
     Optional<std::string> systemVendor;
     Optional<std::string> systemModel;
     Optional<float> systemFieldStrength_T;
@@ -247,84 +236,56 @@ namespace ISMRMRD
     Optional<std::string> stationName;
     Optional<std::string> deviceID;
     Optional<std::string> deviceSerialNumber;
-  };
+};
 
+struct ExperimentalConditions {
+    std::int64_t H1resonanceFrequency_Hz;
+};
 
-  struct ExperimentalConditions
-  {
-      std::int64_t H1resonanceFrequency_Hz;
-  };
-
-  struct MatrixSize
-  {
+struct MatrixSize {
     MatrixSize()
-    : x(1)
-    , y(1)
-    , z(1)
-    {
-
+        : x(1), y(1), z(1) {
     }
-    
+
     MatrixSize(std::uint16_t x, std::uint16_t y)
-    : x(x)
-    , y(y)
-    , z(1)
-    {
-
+        : x(x), y(y), z(1) {
     }
-    
-    MatrixSize(std::uint16_t x, std::uint16_t y, std::uint16_t z)
-    : x(x)
-    , y(y)
-    , z(z)
-    {
 
+    MatrixSize(std::uint16_t x, std::uint16_t y, std::uint16_t z)
+        : x(x), y(y), z(z) {
     }
 
     std::uint16_t x;
     std::uint16_t y;
     std::uint16_t z;
-  };
+};
 
-  struct FieldOfView_mm
-  {
+struct FieldOfView_mm {
     float x;
     float y;
     float z;
-  };
+};
 
-  struct EncodingSpace
-  {
+struct EncodingSpace {
     MatrixSize matrixSize;
     FieldOfView_mm fieldOfView_mm;
-  };
+};
 
-
-  struct Limit
-  {
-    Limit() 
-    : minimum(0)
-    , maximum(0)
-    , center(0)
-    {
-
+struct Limit {
+    Limit()
+        : minimum(0), maximum(0), center(0) {
     }
-    
-    Limit(std::uint16_t minimum, std::uint16_t maximum, std::uint16_t center) 
-    : minimum(minimum)
-    , maximum(maximum)
-    , center(center)
-    {
 
+    Limit(std::uint16_t minimum, std::uint16_t maximum, std::uint16_t center)
+        : minimum(minimum), maximum(maximum), center(center) {
     }
 
     std::uint16_t minimum;
     std::uint16_t maximum;
     std::uint16_t center;
-  };
+};
 
-  struct EncodingLimits
-  {
+struct EncodingLimits {
     Optional<Limit> kspace_encoding_step_0;
     Optional<Limit> kspace_encoding_step_1;
     Optional<Limit> kspace_encoding_step_2;
@@ -335,91 +296,79 @@ namespace ISMRMRD
     Optional<Limit> repetition;
     Optional<Limit> set;
     Optional<Limit> segment;
-    std::array<Optional<Limit>,ISMRMRD_USER_INTS> user;
-  };
+    std::array<Optional<Limit>, ISMRMRD_USER_INTS> user;
+};
 
-
-  struct UserParameterLong
-  {
+struct UserParameterLong {
     std::string name;
     std::int64_t value;
-  };
+};
 
-  struct UserParameterDouble
-  {
+struct UserParameterDouble {
     std::string name;
     double value;
-  };
-  
-  struct UserParameterString
-  {
-      std::string name;
-    std::string value;
-  };
+};
 
-  struct UserParameters
-  {
+struct UserParameterString {
+    std::string name;
+    std::string value;
+};
+
+struct UserParameters {
     std::vector<UserParameterLong> userParameterLong;
     std::vector<UserParameterDouble> userParameterDouble;
     std::vector<UserParameterString> userParameterString;
     std::vector<UserParameterString> userParameterBase64;
-  };
+};
 
-  struct TrajectoryDescription
-  {
+struct TrajectoryDescription {
     std::string identifier;
     std::vector<UserParameterLong> userParameterLong;
     std::vector<UserParameterDouble> userParameterDouble;
     std::vector<UserParameterString> userParameterString;
-    Optional<std::string> comment; 
-  };
+    Optional<std::string> comment;
+};
 
-  struct AccelerationFactor
-  {
+struct AccelerationFactor {
     std::uint16_t kspace_encoding_step_1;
     std::uint16_t kspace_encoding_step_2;
-  };
+};
 
+enum class TrajectoryType {
+    CARTESIAN,
+    EPI,
+    RADIAL,
+    GOLDENANGLE,
+    SPIRAL,
+    OTHER
+};
 
-  enum class TrajectoryType {
-      CARTESIAN,
-      EPI,
-      RADIAL,
-      GOLDENANGLE,
-      SPIRAL,
-      OTHER
-  };
-
-
-
-  enum class MultibandCalibrationType {
+enum class MultibandCalibrationType {
     SEPARABLE2D,
     FULL3D,
     OTHER
-  };
+};
 
-  struct MultibandSpacing {
-      std::vector<float> dZ;
-  };
+struct MultibandSpacing {
+    std::vector<float> dZ;
+};
 
-  struct Multiband{
+struct Multiband {
     std::vector<MultibandSpacing> spacing;
     float deltaKz;
     std::uint32_t multiband_factor;
     MultibandCalibrationType calibration;
     std::uint64_t calibration_encoding;
-  };
+};
 
-  struct ParallelImaging
-  {
+struct ParallelImaging {
     AccelerationFactor accelerationFactor;
     Optional<std::string> calibrationMode;
     Optional<std::string> interleavingDimension;
     Optional<Multiband> multiband;
-  };
+};
 
-  struct Encoding
-  {
+struct Encoding {
     EncodingSpace encodedSpace;
     EncodingSpace reconSpace;
     EncodingLimits encodingLimits;
@@ -427,39 +376,38 @@ namespace ISMRMRD
     Optional<TrajectoryDescription> trajectoryDescription;
     Optional<ParallelImaging> parallelImaging;
     Optional<std::int64_t> echoTrainLength;
-  };
+};
 
-   struct GradientDirection {
-      //In patient coordinate system. Unit vector
-      float rl;
-      float ap;
-      float fh;
-  };
+struct GradientDirection {
+    // In patient coordinate system. Unit vector
+    float rl;
+    float ap;
+    float fh;
+};
 
-  enum class DiffusionDimension {
-      AVERAGE,
-      CONTRAST,
-      PHASE,
-      REPETITION,
-      SET,
-      SEGMENT,
-      USER_0,
-      USER_1,
-      USER_2,
-      USER_3,
-      USER_4,
-      USER_5,
-      USER_6,
-      USER_7
-  };
+enum class DiffusionDimension {
+    AVERAGE,
+    CONTRAST,
+    PHASE,
+    REPETITION,
+    SET,
+    SEGMENT,
+    USER_0,
+    USER_1,
+    USER_2,
+    USER_3,
+    USER_4,
+    USER_5,
+    USER_6,
+    USER_7
+};
 
-  struct Diffusion {
-      float bvalue;
-      GradientDirection gradientDirection;
-  };
+struct Diffusion {
+    float bvalue;
+    GradientDirection gradientDirection;
+};
 
-  struct SequenceParameters
-  {
+struct SequenceParameters {
     Optional<std::vector<float> > TR;
     Optional<std::vector<float> > TE;
     Optional<std::vector<float> > TI;
@@ -467,28 +415,26 @@ namespace ISMRMRD
     Optional<std::string> sequence_type;
     Optional<std::vector<float> > echo_spacing;
     Optional<DiffusionDimension> diffusionDimension;
-    Optional<std::vector<Diffusion>> diffusion;
+    Optional<std::vector<Diffusion> > diffusion;
     Optional<std::string> diffusionScheme;
-  };
+};
 
-  enum class WaveformType {
-      ECG,
-      PULSE,
-      RESPIRATORY,
-      TRIGGER,
-      GRADIENTWAVEFORM,
-      OTHER
-  };
+enum class WaveformType {
+    ECG,
+    PULSE,
+    RESPIRATORY,
+    TRIGGER,
+    GRADIENTWAVEFORM,
+    OTHER
+};
 
+struct WaveformInformation {
+    std::string waveformName;
+    WaveformType waveformType;
+    Optional<UserParameters> userParameters;
+};
 
-  struct WaveformInformation{
-      std::string waveformName;
-      WaveformType waveformType;
-      Optional<UserParameters> userParameters;
-  };
-
-  struct IsmrmrdHeader
-  {
+struct IsmrmrdHeader {
     Optional<std::int64_t> version;
     Optional<SubjectInformation> subjectInformation;
     Optional<StudyInformation> studyInformation;
@@ -499,76 +445,74 @@ namespace ISMRMRD
     Optional<SequenceParameters> sequenceParameters;
     Optional<UserParameters> userParameters;
     std::vector<WaveformInformation> waveformInformation;
-  };
+};
 
+EXPORTISMRMRD void deserialize(const char *xml, IsmrmrdHeader &h);
+EXPORTISMRMRD void serialize(const IsmrmrdHeader &h, std::ostream &o);
 
-    EXPORTISMRMRD void deserialize(const char* xml, IsmrmrdHeader& h);
-    EXPORTISMRMRD void serialize(const IsmrmrdHeader& h, std::ostream& o);
+EXPORTISMRMRD std::ostream &operator<<(std::ostream &os, const IsmrmrdHeader &);
 
-    EXPORTISMRMRD std::ostream& operator<<(std::ostream & os, const IsmrmrdHeader&);
-
- EXPORTISMRMRD bool operator==(const IsmrmrdHeader&, const IsmrmrdHeader&);
- EXPORTISMRMRD bool operator!=(const IsmrmrdHeader &lhs, const IsmrmrdHeader &rhs);
- EXPORTISMRMRD bool operator==(const SubjectInformation &lhs, const SubjectInformation &rhs);
- EXPORTISMRMRD bool operator!=(const SubjectInformation &lhs, const SubjectInformation &rhs);
- EXPORTISMRMRD bool operator==(const StudyInformation &lhs, const StudyInformation &rhs);
- EXPORTISMRMRD bool operator!=(const StudyInformation &lhs, const StudyInformation &rhs);
- EXPORTISMRMRD bool operator==(const ReferencedImageSequence &lhs, const ReferencedImageSequence &rhs);
- EXPORTISMRMRD bool operator!=(const ReferencedImageSequence &lhs, const ReferencedImageSequence &rhs);
- EXPORTISMRMRD bool operator==(const MeasurementInformation &lhs, const MeasurementInformation &rhs);
- EXPORTISMRMRD bool operator!=(const MeasurementInformation &lhs, const MeasurementInformation &rhs);
- EXPORTISMRMRD bool operator==(const CoilLabel &lhs, const CoilLabel &rhs);
- EXPORTISMRMRD bool operator!=(const CoilLabel &lhs, const CoilLabel &rhs);
- EXPORTISMRMRD bool operator==(const AcquisitionSystemInformation &lhs, const AcquisitionSystemInformation &rhs);
- EXPORTISMRMRD bool operator!=(const AcquisitionSystemInformation &lhs, const AcquisitionSystemInformation &rhs);
- EXPORTISMRMRD bool operator==(const ExperimentalConditions &lhs, const ExperimentalConditions &rhs);
- EXPORTISMRMRD bool operator!=(const ExperimentalConditions &lhs, const ExperimentalConditions &rhs);
- EXPORTISMRMRD bool operator==(const MatrixSize &lhs, const MatrixSize &rhs);
- EXPORTISMRMRD bool operator!=(const MatrixSize &lhs, const MatrixSize &rhs);
- EXPORTISMRMRD bool operator==(const FieldOfView_mm &lhs, const FieldOfView_mm &rhs);
- EXPORTISMRMRD bool operator!=(const FieldOfView_mm &lhs, const FieldOfView_mm &rhs);
- EXPORTISMRMRD bool operator==(const EncodingSpace &lhs, const EncodingSpace &rhs);
- EXPORTISMRMRD bool operator!=(const EncodingSpace &lhs, const EncodingSpace &rhs);
- EXPORTISMRMRD bool operator==(const Limit &lhs, const Limit &rhs);
- EXPORTISMRMRD bool operator!=(const Limit &lhs, const Limit &rhs);
- EXPORTISMRMRD bool operator==(const EncodingLimits &lhs, const EncodingLimits &rhs);
- EXPORTISMRMRD bool operator!=(const EncodingLimits &lhs, const EncodingLimits &rhs);
- EXPORTISMRMRD bool operator==(const UserParameterLong &lhs, const UserParameterLong &rhs);
- EXPORTISMRMRD bool operator!=(const UserParameterLong &lhs, const UserParameterLong &rhs);
- EXPORTISMRMRD bool operator==(const UserParameterDouble &lhs, const UserParameterDouble &rhs);
- EXPORTISMRMRD bool operator!=(const UserParameterDouble &lhs, const UserParameterDouble &rhs);
- EXPORTISMRMRD bool operator==(const UserParameterString &lhs, const UserParameterString &rhs);
- EXPORTISMRMRD bool operator!=(const UserParameterString &lhs, const UserParameterString &rhs);
- EXPORTISMRMRD bool operator==(const UserParameters &lhs, const UserParameters &rhs);
- EXPORTISMRMRD bool operator!=(const UserParameters &lhs, const UserParameters &rhs);
- EXPORTISMRMRD bool operator==(const TrajectoryDescription &lhs, const TrajectoryDescription &rhs);
- EXPORTISMRMRD bool operator!=(const TrajectoryDescription &lhs, const TrajectoryDescription &rhs);
- EXPORTISMRMRD bool operator==(const AccelerationFactor &lhs, const AccelerationFactor &rhs);
- EXPORTISMRMRD bool operator!=(const AccelerationFactor &lhs, const AccelerationFactor &rhs);
- EXPORTISMRMRD bool operator==(const ParallelImaging &lhs, const ParallelImaging &rhs);
- EXPORTISMRMRD bool operator!=(const ParallelImaging &lhs, const ParallelImaging &rhs);
- EXPORTISMRMRD bool operator==(const Multiband &lhs, const Multiband &rhs);
- EXPORTISMRMRD bool operator!=(const Multiband &lhs, const Multiband &rhs);
- EXPORTISMRMRD bool operator==(const MultibandSpacing &lhs, const MultibandSpacing &rhs);
- EXPORTISMRMRD bool operator!=(const MultibandSpacing &lhs, const MultibandSpacing &rhs);
- EXPORTISMRMRD bool operator==(const Encoding &lhs, const Encoding &rhs);
- EXPORTISMRMRD bool operator!=(const Encoding &lhs, const Encoding &rhs);
- EXPORTISMRMRD bool operator==(const SequenceParameters &lhs, const SequenceParameters &rhs);
- EXPORTISMRMRD bool operator!=(const SequenceParameters &lhs, const SequenceParameters &rhs);
- EXPORTISMRMRD bool operator==(const WaveformInformation &lhs, const WaveformInformation &rhs);
- EXPORTISMRMRD bool operator!=(const WaveformInformation &lhs, const WaveformInformation &rhs);
- EXPORTISMRMRD bool operator==(const threeDimensionalFloat &lhs, const threeDimensionalFloat &rhs);
- EXPORTISMRMRD bool operator!=(const threeDimensionalFloat &lhs, const threeDimensionalFloat &rhs);
- EXPORTISMRMRD bool operator==(const MeasurementDependency &lhs, const MeasurementDependency &rhs);
- EXPORTISMRMRD bool operator!=(const MeasurementDependency &lhs, const MeasurementDependency &rhs);
- EXPORTISMRMRD bool operator==(const GradientDirection &lhs, const GradientDirection &rhs);
- EXPORTISMRMRD bool operator!=(const GradientDirection &lhs, const GradientDirection &rhs);
- EXPORTISMRMRD bool operator==(const Diffusion &lhs, const Diffusion &rhs);
- EXPORTISMRMRD bool operator!=(const Diffusion &lhs, const Diffusion &rhs);
-
+EXPORTISMRMRD bool operator==(const IsmrmrdHeader &, const IsmrmrdHeader &);
+EXPORTISMRMRD bool operator!=(const IsmrmrdHeader &lhs, const IsmrmrdHeader &rhs);
+EXPORTISMRMRD bool operator==(const SubjectInformation &lhs, const SubjectInformation &rhs);
+EXPORTISMRMRD bool operator!=(const SubjectInformation &lhs, const SubjectInformation &rhs);
+EXPORTISMRMRD bool operator==(const StudyInformation &lhs, const StudyInformation &rhs);
+EXPORTISMRMRD bool operator!=(const StudyInformation &lhs, const StudyInformation &rhs);
+EXPORTISMRMRD bool operator==(const ReferencedImageSequence &lhs, const ReferencedImageSequence &rhs);
+EXPORTISMRMRD bool operator!=(const ReferencedImageSequence &lhs, const ReferencedImageSequence &rhs);
+EXPORTISMRMRD bool operator==(const MeasurementInformation &lhs, const MeasurementInformation &rhs);
+EXPORTISMRMRD bool operator!=(const MeasurementInformation &lhs, const MeasurementInformation &rhs);
+EXPORTISMRMRD bool operator==(const CoilLabel &lhs, const CoilLabel &rhs);
+EXPORTISMRMRD bool operator!=(const CoilLabel &lhs, const CoilLabel &rhs);
+EXPORTISMRMRD bool operator==(const AcquisitionSystemInformation &lhs, const AcquisitionSystemInformation &rhs);
+EXPORTISMRMRD bool operator!=(const AcquisitionSystemInformation &lhs, const AcquisitionSystemInformation &rhs);
+EXPORTISMRMRD bool operator==(const ExperimentalConditions &lhs, const ExperimentalConditions &rhs);
+EXPORTISMRMRD bool operator!=(const ExperimentalConditions &lhs, const ExperimentalConditions &rhs);
+EXPORTISMRMRD bool operator==(const MatrixSize &lhs, const MatrixSize &rhs);
+EXPORTISMRMRD bool operator!=(const MatrixSize &lhs, const MatrixSize &rhs);
+EXPORTISMRMRD bool operator==(const FieldOfView_mm &lhs, const FieldOfView_mm &rhs);
+EXPORTISMRMRD bool operator!=(const FieldOfView_mm &lhs, const FieldOfView_mm &rhs);
+EXPORTISMRMRD bool operator==(const EncodingSpace &lhs, const EncodingSpace &rhs);
+EXPORTISMRMRD bool operator!=(const EncodingSpace &lhs, const EncodingSpace &rhs);
+EXPORTISMRMRD bool operator==(const Limit &lhs, const Limit &rhs);
+EXPORTISMRMRD bool operator!=(const Limit &lhs, const Limit &rhs);
+EXPORTISMRMRD bool operator==(const EncodingLimits &lhs, const EncodingLimits &rhs);
+EXPORTISMRMRD bool operator!=(const EncodingLimits &lhs, const EncodingLimits &rhs);
+EXPORTISMRMRD bool operator==(const UserParameterLong &lhs, const UserParameterLong &rhs);
+EXPORTISMRMRD bool operator!=(const UserParameterLong &lhs, const UserParameterLong &rhs);
+EXPORTISMRMRD bool operator==(const UserParameterDouble &lhs, const UserParameterDouble &rhs);
+EXPORTISMRMRD bool operator!=(const UserParameterDouble &lhs, const UserParameterDouble &rhs);
+EXPORTISMRMRD bool operator==(const UserParameterString &lhs, const UserParameterString &rhs);
+EXPORTISMRMRD bool operator!=(const UserParameterString &lhs, const UserParameterString &rhs);
+EXPORTISMRMRD bool operator==(const UserParameters &lhs, const UserParameters &rhs);
+EXPORTISMRMRD bool operator!=(const UserParameters &lhs, const UserParameters &rhs);
+EXPORTISMRMRD bool operator==(const TrajectoryDescription &lhs, const TrajectoryDescription &rhs);
+EXPORTISMRMRD bool operator!=(const TrajectoryDescription &lhs, const TrajectoryDescription &rhs);
+EXPORTISMRMRD bool operator==(const AccelerationFactor &lhs, const AccelerationFactor &rhs);
+EXPORTISMRMRD bool operator!=(const AccelerationFactor &lhs, const AccelerationFactor &rhs);
+EXPORTISMRMRD bool operator==(const ParallelImaging &lhs, const ParallelImaging &rhs);
+EXPORTISMRMRD bool operator!=(const ParallelImaging &lhs, const ParallelImaging &rhs);
+EXPORTISMRMRD bool operator==(const Multiband &lhs, const Multiband &rhs);
+EXPORTISMRMRD bool operator!=(const Multiband &lhs, const Multiband &rhs);
+EXPORTISMRMRD bool operator==(const MultibandSpacing &lhs, const MultibandSpacing &rhs);
+EXPORTISMRMRD bool operator!=(const MultibandSpacing &lhs, const MultibandSpacing &rhs);
+EXPORTISMRMRD bool operator==(const Encoding &lhs, const Encoding &rhs);
+EXPORTISMRMRD bool operator!=(const Encoding &lhs, const Encoding &rhs);
+EXPORTISMRMRD bool operator==(const SequenceParameters &lhs, const SequenceParameters &rhs);
+EXPORTISMRMRD bool operator!=(const SequenceParameters &lhs, const SequenceParameters &rhs);
+EXPORTISMRMRD bool operator==(const WaveformInformation &lhs, const WaveformInformation &rhs);
+EXPORTISMRMRD bool operator!=(const WaveformInformation &lhs, const WaveformInformation &rhs);
+EXPORTISMRMRD bool operator==(const threeDimensionalFloat &lhs, const threeDimensionalFloat &rhs);
+EXPORTISMRMRD bool operator!=(const threeDimensionalFloat &lhs, const threeDimensionalFloat &rhs);
+EXPORTISMRMRD bool operator==(const MeasurementDependency &lhs, const MeasurementDependency &rhs);
+EXPORTISMRMRD bool operator!=(const MeasurementDependency &lhs, const MeasurementDependency &rhs);
+EXPORTISMRMRD bool operator==(const GradientDirection &lhs, const GradientDirection &rhs);
+EXPORTISMRMRD bool operator!=(const GradientDirection &lhs, const GradientDirection &rhs);
+EXPORTISMRMRD bool operator==(const Diffusion &lhs, const Diffusion &rhs);
+EXPORTISMRMRD bool operator!=(const Diffusion &lhs, const Diffusion &rhs);
 
 /** @} */
 
-}
+} // namespace ISMRMRD
 
-#endif //ISMRMRDXML_H
+#endif // ISMRMRDXML_H

--- a/include/ismrmrd/xml.h
+++ b/include/ismrmrd/xml.h
@@ -6,18 +6,18 @@
 #ifndef ISMRMRDXML_H
 #define ISMRMRDXML_H
 
-#include "ismrmrd.h"
 #include "ismrmrd/export.h"
-#include <array>
+#include "ismrmrd.h"
 #include <cstddef>
-#include <cstdint>
-#include <iostream>
-#include <new>       //For std::badalloc
+#include <new> //For std::badalloc
 #include <stdexcept> //For std::length_error
+#include <cstdint>
 #include <stdio.h>
 #include <string.h>
+#include <iostream>
 #include <string>
 #include <vector>
+#include <array>
 
 /**
   TODO LIST
@@ -32,157 +32,164 @@
  * @{
  */
 
-namespace ISMRMRD {
+namespace ISMRMRD
+{
 
-template <typename T>
-class Optional {
-public:
+  template <typename T> class Optional
+  {
+  public:
     Optional()
-        : present_(false) {
+      : present_(false)
+    {
+
     }
 
-    Optional(const T &v) {
-        present_ = true;
-        value_ = v;
+    Optional(const T&v) {
+      present_ = true;
+      value_ = v;      
     }
 
-    Optional &operator=(const Optional &o) {
-        present_ = o.present_;
-        if (present_)
-            value_ = o.value_;
-        return *this;
+	Optional& operator=(const Optional& o) {
+		present_ = o.present_;
+		if (present_)
+			value_ = o.value_;	
+		return *this;
+	}
+
+    Optional& operator=(const T& v) {
+      present_ = true;
+      value_ = v;
+      return *this;
     }
 
-    Optional &operator=(const T &v) {
-        present_ = true;
-        value_ = v;
-        return *this;
+     T* operator->() {
+      return &value_;
     }
 
-    T *operator->() {
-        return &value_;
+    T& operator*() {
+      return value_;
     }
 
-    T &operator*() {
-        return value_;
+    const T* operator->() const {
+      return &value_;
     }
 
-    const T *operator->() const {
-        return &value_;
-    }
-
-    const T &operator*() const {
-        return value_;
+    const T& operator*() const {
+      return value_;
     }
 
     operator bool() const {
-        return present_;
+      return present_;
     }
 
     bool is_present() const {
-        return present_;
+      return present_;
     }
 
     bool has_value() const noexcept {
         return present_;
     }
 
-    T &value() & {
-        if (!present_) {
-            throw std::runtime_error("Access optional value, which has not been set");
-        }
-        return value_;
+
+  T &value() &{
+      if (!present_) {
+          throw std::runtime_error("Access optional value, which has not been set");
+      }
+      return value_;
+  }
+
+
+  const T &value() const &{
+      if (!present_) {
+          throw std::runtime_error("Access optional value, which has not been set");
+      }
+      return value_;
+  }
+
+  T &&value() &&{
+      if (!present_) {
+          throw std::runtime_error("Access optional value, which has not been set");
+      }
+      return std::move(value_);
+  }
+
+  const T &&value() const &&{
+      if (!present_) {
+          throw std::runtime_error("Access optional value, which has not been set");
+      }
+      return std::move(value_);
+  }
+
+  T &get() & {
+      return  this->value();
     }
 
-    const T &value() const & {
-        if (!present_) {
-            throw std::runtime_error("Access optional value, which has not been set");
-        }
-        return value_;
-    }
-
-    T &&value() && {
-        if (!present_) {
-            throw std::runtime_error("Access optional value, which has not been set");
-        }
-        return std::move(value_);
-    }
-
-    const T &&value() const && {
-        if (!present_) {
-            throw std::runtime_error("Access optional value, which has not been set");
-        }
-        return std::move(value_);
-    }
-
-    T &get() & {
+    T&& get()&&{
         return this->value();
     }
+     const T &get() const &  {
+          return  this->value();
+      }
 
-    T &&get() && {
-        return this->value();
-    }
-    const T &get() const & {
-        return this->value();
-    }
+     const  T&& get() const &&{
+          return this->value();
+      }
+  template<class U>
+  T value_or(U &&default_value) const &{
+      return bool(*this) ? **this : static_cast<T>(std::forward<U>(default_value));
+  }
 
-    const T &&get() const && {
-        return this->value();
-    }
-    template <class U>
-    T value_or(U &&default_value) const & {
-        return bool(*this) ? **this : static_cast<T>(std::forward<U>(default_value));
-    }
+  template<class U>
+  T value_or(U &&default_value) &&{
+      return bool(*this) ? std::move(**this) : static_cast<T>(std::forward<U>(default_value));
+  }
 
-    template <class U>
-    T value_or(U &&default_value) && {
-        return bool(*this) ? std::move(**this) : static_cast<T>(std::forward<U>(default_value));
-    }
-
-    bool operator==(const Optional<T> &other) const {
-        if (this->present_ && other.present_)
-            return this->get() == *other;
-        if ((!this->present_) && (!other.present_))
-            return true;
-        return false;
+    bool operator==(const Optional<T>& other) const {
+      if (this->present_ && other.present_) return this->get() == *other;
+      if ((!this->present_) && (!other.present_)) return true;
+      return false;
     }
 
-    bool operator==(const T &val) const {
-        if (this->present_)
-            return this->get() == val;
-        return false;
+    bool operator==(const T& val) const {
+      if (this->present_) return this->get() == val;
+      return false; 
     }
 
-    T &operator()() {
-        return value();
+
+  T& operator()() {
+  return value();
+}
+
+    void set(const T& v) {
+      present_ = true;
+      value_ = v;
     }
 
-    void set(const T &v) {
-        present_ = true;
-        value_ = v;
-    }
-
-protected:
+  protected:
     bool present_;
     T value_;
-};
 
-struct threeDimensionalFloat {
+  }; 
+
+  struct threeDimensionalFloat
+  {
     float x;
     float y;
     float z;
-};
+  };
 
-struct SubjectInformation {
+  struct SubjectInformation 
+  {
     Optional<std::string> patientName;
     Optional<float> patientWeight_kg;
     Optional<float> patientHeight_m;
     Optional<std::string> patientID;
     Optional<std::string> patientBirthdate;
     Optional<std::string> patientGender;
-};
+  };
 
-struct StudyInformation {
+  struct StudyInformation
+  {
 
     Optional<std::string> studyDate;
     Optional<std::string> studyTime;
@@ -192,19 +199,22 @@ struct StudyInformation {
     Optional<std::string> studyDescription;
     Optional<std::string> studyInstanceUID;
     Optional<std::string> bodyPartExamined;
-};
+  };
 
-struct MeasurementDependency {
+  struct MeasurementDependency
+  {
 
-    std::string dependencyType;
+      std::string dependencyType;
     std::string measurementID;
-};
+  };
 
-struct ReferencedImageSequence {
-    std::string referencedSOPInstanceUID;
-};
-
-struct MeasurementInformation {
+  struct ReferencedImageSequence
+  {
+      std::string referencedSOPInstanceUID;
+  };
+  
+  struct MeasurementInformation
+  {
     Optional<std::string> measurementID;
     Optional<std::string> seriesDate;
     Optional<std::string> seriesTime;
@@ -218,14 +228,16 @@ struct MeasurementInformation {
     Optional<std::string> seriesInstanceUIDRoot;
     Optional<std::string> frameOfReferenceUID;
     std::vector<ReferencedImageSequence> referencedImageSequence;
-};
+  };
 
-struct CoilLabel {
+  struct CoilLabel
+  {
     std::uint16_t coilNumber;
     std::string coilName;
-};
-
-struct AcquisitionSystemInformation {
+  };
+  
+  struct AcquisitionSystemInformation
+  {
     Optional<std::string> systemVendor;
     Optional<std::string> systemModel;
     Optional<float> systemFieldStrength_T;
@@ -236,56 +248,84 @@ struct AcquisitionSystemInformation {
     Optional<std::string> stationName;
     Optional<std::string> deviceID;
     Optional<std::string> deviceSerialNumber;
-};
+  };
 
-struct ExperimentalConditions {
-    std::int64_t H1resonanceFrequency_Hz;
-};
 
-struct MatrixSize {
+  struct ExperimentalConditions
+  {
+      std::int64_t H1resonanceFrequency_Hz;
+  };
+
+  struct MatrixSize
+  {
     MatrixSize()
-        : x(1), y(1), z(1) {
-    }
+    : x(1)
+    , y(1)
+    , z(1)
+    {
 
+    }
+    
     MatrixSize(std::uint16_t x, std::uint16_t y)
-        : x(x), y(y), z(1) {
-    }
+    : x(x)
+    , y(y)
+    , z(1)
+    {
 
+    }
+    
     MatrixSize(std::uint16_t x, std::uint16_t y, std::uint16_t z)
-        : x(x), y(y), z(z) {
+    : x(x)
+    , y(y)
+    , z(z)
+    {
+
     }
 
     std::uint16_t x;
     std::uint16_t y;
     std::uint16_t z;
-};
+  };
 
-struct FieldOfView_mm {
+  struct FieldOfView_mm
+  {
     float x;
     float y;
     float z;
-};
+  };
 
-struct EncodingSpace {
+  struct EncodingSpace
+  {
     MatrixSize matrixSize;
     FieldOfView_mm fieldOfView_mm;
-};
+  };
 
-struct Limit {
-    Limit()
-        : minimum(0), maximum(0), center(0) {
+
+  struct Limit
+  {
+    Limit() 
+    : minimum(0)
+    , maximum(0)
+    , center(0)
+    {
+
     }
+    
+    Limit(std::uint16_t minimum, std::uint16_t maximum, std::uint16_t center) 
+    : minimum(minimum)
+    , maximum(maximum)
+    , center(center)
+    {
 
-    Limit(std::uint16_t minimum, std::uint16_t maximum, std::uint16_t center)
-        : minimum(minimum), maximum(maximum), center(center) {
     }
 
     std::uint16_t minimum;
     std::uint16_t maximum;
     std::uint16_t center;
-};
+  };
 
-struct EncodingLimits {
+  struct EncodingLimits
+  {
     Optional<Limit> kspace_encoding_step_0;
     Optional<Limit> kspace_encoding_step_1;
     Optional<Limit> kspace_encoding_step_2;
@@ -296,79 +336,91 @@ struct EncodingLimits {
     Optional<Limit> repetition;
     Optional<Limit> set;
     Optional<Limit> segment;
-    std::array<Optional<Limit>, ISMRMRD_USER_INTS> user;
-};
+    std::array<Optional<Limit>,ISMRMRD_USER_INTS> user;
+  };
 
-struct UserParameterLong {
+
+  struct UserParameterLong
+  {
     std::string name;
     std::int64_t value;
-};
+  };
 
-struct UserParameterDouble {
+  struct UserParameterDouble
+  {
     std::string name;
     double value;
-};
-
-struct UserParameterString {
-    std::string name;
+  };
+  
+  struct UserParameterString
+  {
+      std::string name;
     std::string value;
-};
+  };
 
-struct UserParameters {
+  struct UserParameters
+  {
     std::vector<UserParameterLong> userParameterLong;
     std::vector<UserParameterDouble> userParameterDouble;
     std::vector<UserParameterString> userParameterString;
     std::vector<UserParameterString> userParameterBase64;
-};
+  };
 
-struct TrajectoryDescription {
+  struct TrajectoryDescription
+  {
     std::string identifier;
     std::vector<UserParameterLong> userParameterLong;
     std::vector<UserParameterDouble> userParameterDouble;
     std::vector<UserParameterString> userParameterString;
-    Optional<std::string> comment;
-};
+    Optional<std::string> comment; 
+  };
 
-struct AccelerationFactor {
+  struct AccelerationFactor
+  {
     std::uint16_t kspace_encoding_step_1;
     std::uint16_t kspace_encoding_step_2;
-};
+  };
 
-enum class TrajectoryType {
-    CARTESIAN,
-    EPI,
-    RADIAL,
-    GOLDENANGLE,
-    SPIRAL,
-    OTHER
-};
 
-enum class MultibandCalibrationType {
+  enum class TrajectoryType {
+      CARTESIAN,
+      EPI,
+      RADIAL,
+      GOLDENANGLE,
+      SPIRAL,
+      OTHER
+  };
+
+
+
+  enum class MultibandCalibrationType {
     SEPARABLE2D,
     FULL3D,
     OTHER
-};
+  };
 
-struct MultibandSpacing {
-    std::vector<float> dZ;
-};
+  struct MultibandSpacing {
+      std::vector<float> dZ;
+  };
 
-struct Multiband {
+  struct Multiband{
     std::vector<MultibandSpacing> spacing;
     float deltaKz;
     std::uint32_t multiband_factor;
     MultibandCalibrationType calibration;
     std::uint64_t calibration_encoding;
-};
+  };
 
-struct ParallelImaging {
+  struct ParallelImaging
+  {
     AccelerationFactor accelerationFactor;
     Optional<std::string> calibrationMode;
     Optional<std::string> interleavingDimension;
     Optional<Multiband> multiband;
-};
+  };
 
-struct Encoding {
+  struct Encoding
+  {
     EncodingSpace encodedSpace;
     EncodingSpace reconSpace;
     EncodingLimits encodingLimits;
@@ -376,38 +428,39 @@ struct Encoding {
     Optional<TrajectoryDescription> trajectoryDescription;
     Optional<ParallelImaging> parallelImaging;
     Optional<std::int64_t> echoTrainLength;
-};
+  };
 
-struct GradientDirection {
-    // In patient coordinate system. Unit vector
-    float rl;
-    float ap;
-    float fh;
-};
+   struct GradientDirection {
+      //In patient coordinate system. Unit vector
+      float rl;
+      float ap;
+      float fh;
+  };
 
-enum class DiffusionDimension {
-    AVERAGE,
-    CONTRAST,
-    PHASE,
-    REPETITION,
-    SET,
-    SEGMENT,
-    USER_0,
-    USER_1,
-    USER_2,
-    USER_3,
-    USER_4,
-    USER_5,
-    USER_6,
-    USER_7
-};
+  enum class DiffusionDimension {
+      AVERAGE,
+      CONTRAST,
+      PHASE,
+      REPETITION,
+      SET,
+      SEGMENT,
+      USER_0,
+      USER_1,
+      USER_2,
+      USER_3,
+      USER_4,
+      USER_5,
+      USER_6,
+      USER_7
+  };
 
-struct Diffusion {
-    float bvalue;
-    GradientDirection gradientDirection;
-};
+  struct Diffusion {
+      float bvalue;
+      GradientDirection gradientDirection;
+  };
 
-struct SequenceParameters {
+  struct SequenceParameters
+  {
     Optional<std::vector<float> > TR;
     Optional<std::vector<float> > TE;
     Optional<std::vector<float> > TI;
@@ -415,26 +468,28 @@ struct SequenceParameters {
     Optional<std::string> sequence_type;
     Optional<std::vector<float> > echo_spacing;
     Optional<DiffusionDimension> diffusionDimension;
-    Optional<std::vector<Diffusion> > diffusion;
+    Optional<std::vector<Diffusion>> diffusion;
     Optional<std::string> diffusionScheme;
-};
+  };
 
-enum class WaveformType {
-    ECG,
-    PULSE,
-    RESPIRATORY,
-    TRIGGER,
-    GRADIENTWAVEFORM,
-    OTHER
-};
+  enum class WaveformType {
+      ECG,
+      PULSE,
+      RESPIRATORY,
+      TRIGGER,
+      GRADIENTWAVEFORM,
+      OTHER
+  };
 
-struct WaveformInformation {
-    std::string waveformName;
-    WaveformType waveformType;
-    Optional<UserParameters> userParameters;
-};
 
-struct IsmrmrdHeader {
+  struct WaveformInformation{
+      std::string waveformName;
+      WaveformType waveformType;
+      Optional<UserParameters> userParameters;
+  };
+
+  struct IsmrmrdHeader
+  {
     Optional<std::int64_t> version;
     Optional<SubjectInformation> subjectInformation;
     Optional<StudyInformation> studyInformation;
@@ -445,74 +500,76 @@ struct IsmrmrdHeader {
     Optional<SequenceParameters> sequenceParameters;
     Optional<UserParameters> userParameters;
     std::vector<WaveformInformation> waveformInformation;
-};
+  };
 
-EXPORTISMRMRD void deserialize(const char *xml, IsmrmrdHeader &h);
-EXPORTISMRMRD void serialize(const IsmrmrdHeader &h, std::ostream &o);
 
-EXPORTISMRMRD std::ostream &operator<<(std::ostream &os, const IsmrmrdHeader &);
+    EXPORTISMRMRD void deserialize(const char* xml, IsmrmrdHeader& h);
+    EXPORTISMRMRD void serialize(const IsmrmrdHeader& h, std::ostream& o);
 
-EXPORTISMRMRD bool operator==(const IsmrmrdHeader &, const IsmrmrdHeader &);
-EXPORTISMRMRD bool operator!=(const IsmrmrdHeader &lhs, const IsmrmrdHeader &rhs);
-EXPORTISMRMRD bool operator==(const SubjectInformation &lhs, const SubjectInformation &rhs);
-EXPORTISMRMRD bool operator!=(const SubjectInformation &lhs, const SubjectInformation &rhs);
-EXPORTISMRMRD bool operator==(const StudyInformation &lhs, const StudyInformation &rhs);
-EXPORTISMRMRD bool operator!=(const StudyInformation &lhs, const StudyInformation &rhs);
-EXPORTISMRMRD bool operator==(const ReferencedImageSequence &lhs, const ReferencedImageSequence &rhs);
-EXPORTISMRMRD bool operator!=(const ReferencedImageSequence &lhs, const ReferencedImageSequence &rhs);
-EXPORTISMRMRD bool operator==(const MeasurementInformation &lhs, const MeasurementInformation &rhs);
-EXPORTISMRMRD bool operator!=(const MeasurementInformation &lhs, const MeasurementInformation &rhs);
-EXPORTISMRMRD bool operator==(const CoilLabel &lhs, const CoilLabel &rhs);
-EXPORTISMRMRD bool operator!=(const CoilLabel &lhs, const CoilLabel &rhs);
-EXPORTISMRMRD bool operator==(const AcquisitionSystemInformation &lhs, const AcquisitionSystemInformation &rhs);
-EXPORTISMRMRD bool operator!=(const AcquisitionSystemInformation &lhs, const AcquisitionSystemInformation &rhs);
-EXPORTISMRMRD bool operator==(const ExperimentalConditions &lhs, const ExperimentalConditions &rhs);
-EXPORTISMRMRD bool operator!=(const ExperimentalConditions &lhs, const ExperimentalConditions &rhs);
-EXPORTISMRMRD bool operator==(const MatrixSize &lhs, const MatrixSize &rhs);
-EXPORTISMRMRD bool operator!=(const MatrixSize &lhs, const MatrixSize &rhs);
-EXPORTISMRMRD bool operator==(const FieldOfView_mm &lhs, const FieldOfView_mm &rhs);
-EXPORTISMRMRD bool operator!=(const FieldOfView_mm &lhs, const FieldOfView_mm &rhs);
-EXPORTISMRMRD bool operator==(const EncodingSpace &lhs, const EncodingSpace &rhs);
-EXPORTISMRMRD bool operator!=(const EncodingSpace &lhs, const EncodingSpace &rhs);
-EXPORTISMRMRD bool operator==(const Limit &lhs, const Limit &rhs);
-EXPORTISMRMRD bool operator!=(const Limit &lhs, const Limit &rhs);
-EXPORTISMRMRD bool operator==(const EncodingLimits &lhs, const EncodingLimits &rhs);
-EXPORTISMRMRD bool operator!=(const EncodingLimits &lhs, const EncodingLimits &rhs);
-EXPORTISMRMRD bool operator==(const UserParameterLong &lhs, const UserParameterLong &rhs);
-EXPORTISMRMRD bool operator!=(const UserParameterLong &lhs, const UserParameterLong &rhs);
-EXPORTISMRMRD bool operator==(const UserParameterDouble &lhs, const UserParameterDouble &rhs);
-EXPORTISMRMRD bool operator!=(const UserParameterDouble &lhs, const UserParameterDouble &rhs);
-EXPORTISMRMRD bool operator==(const UserParameterString &lhs, const UserParameterString &rhs);
-EXPORTISMRMRD bool operator!=(const UserParameterString &lhs, const UserParameterString &rhs);
-EXPORTISMRMRD bool operator==(const UserParameters &lhs, const UserParameters &rhs);
-EXPORTISMRMRD bool operator!=(const UserParameters &lhs, const UserParameters &rhs);
-EXPORTISMRMRD bool operator==(const TrajectoryDescription &lhs, const TrajectoryDescription &rhs);
-EXPORTISMRMRD bool operator!=(const TrajectoryDescription &lhs, const TrajectoryDescription &rhs);
-EXPORTISMRMRD bool operator==(const AccelerationFactor &lhs, const AccelerationFactor &rhs);
-EXPORTISMRMRD bool operator!=(const AccelerationFactor &lhs, const AccelerationFactor &rhs);
-EXPORTISMRMRD bool operator==(const ParallelImaging &lhs, const ParallelImaging &rhs);
-EXPORTISMRMRD bool operator!=(const ParallelImaging &lhs, const ParallelImaging &rhs);
-EXPORTISMRMRD bool operator==(const Multiband &lhs, const Multiband &rhs);
-EXPORTISMRMRD bool operator!=(const Multiband &lhs, const Multiband &rhs);
-EXPORTISMRMRD bool operator==(const MultibandSpacing &lhs, const MultibandSpacing &rhs);
-EXPORTISMRMRD bool operator!=(const MultibandSpacing &lhs, const MultibandSpacing &rhs);
-EXPORTISMRMRD bool operator==(const Encoding &lhs, const Encoding &rhs);
-EXPORTISMRMRD bool operator!=(const Encoding &lhs, const Encoding &rhs);
-EXPORTISMRMRD bool operator==(const SequenceParameters &lhs, const SequenceParameters &rhs);
-EXPORTISMRMRD bool operator!=(const SequenceParameters &lhs, const SequenceParameters &rhs);
-EXPORTISMRMRD bool operator==(const WaveformInformation &lhs, const WaveformInformation &rhs);
-EXPORTISMRMRD bool operator!=(const WaveformInformation &lhs, const WaveformInformation &rhs);
-EXPORTISMRMRD bool operator==(const threeDimensionalFloat &lhs, const threeDimensionalFloat &rhs);
-EXPORTISMRMRD bool operator!=(const threeDimensionalFloat &lhs, const threeDimensionalFloat &rhs);
-EXPORTISMRMRD bool operator==(const MeasurementDependency &lhs, const MeasurementDependency &rhs);
-EXPORTISMRMRD bool operator!=(const MeasurementDependency &lhs, const MeasurementDependency &rhs);
-EXPORTISMRMRD bool operator==(const GradientDirection &lhs, const GradientDirection &rhs);
-EXPORTISMRMRD bool operator!=(const GradientDirection &lhs, const GradientDirection &rhs);
-EXPORTISMRMRD bool operator==(const Diffusion &lhs, const Diffusion &rhs);
-EXPORTISMRMRD bool operator!=(const Diffusion &lhs, const Diffusion &rhs);
+    EXPORTISMRMRD std::ostream& operator<<(std::ostream & os, const IsmrmrdHeader&);
+
+ EXPORTISMRMRD bool operator==(const IsmrmrdHeader&, const IsmrmrdHeader&);
+ EXPORTISMRMRD bool operator!=(const IsmrmrdHeader &lhs, const IsmrmrdHeader &rhs);
+ EXPORTISMRMRD bool operator==(const SubjectInformation &lhs, const SubjectInformation &rhs);
+ EXPORTISMRMRD bool operator!=(const SubjectInformation &lhs, const SubjectInformation &rhs);
+ EXPORTISMRMRD bool operator==(const StudyInformation &lhs, const StudyInformation &rhs);
+ EXPORTISMRMRD bool operator!=(const StudyInformation &lhs, const StudyInformation &rhs);
+ EXPORTISMRMRD bool operator==(const ReferencedImageSequence &lhs, const ReferencedImageSequence &rhs);
+ EXPORTISMRMRD bool operator!=(const ReferencedImageSequence &lhs, const ReferencedImageSequence &rhs);
+ EXPORTISMRMRD bool operator==(const MeasurementInformation &lhs, const MeasurementInformation &rhs);
+ EXPORTISMRMRD bool operator!=(const MeasurementInformation &lhs, const MeasurementInformation &rhs);
+ EXPORTISMRMRD bool operator==(const CoilLabel &lhs, const CoilLabel &rhs);
+ EXPORTISMRMRD bool operator!=(const CoilLabel &lhs, const CoilLabel &rhs);
+ EXPORTISMRMRD bool operator==(const AcquisitionSystemInformation &lhs, const AcquisitionSystemInformation &rhs);
+ EXPORTISMRMRD bool operator!=(const AcquisitionSystemInformation &lhs, const AcquisitionSystemInformation &rhs);
+ EXPORTISMRMRD bool operator==(const ExperimentalConditions &lhs, const ExperimentalConditions &rhs);
+ EXPORTISMRMRD bool operator!=(const ExperimentalConditions &lhs, const ExperimentalConditions &rhs);
+ EXPORTISMRMRD bool operator==(const MatrixSize &lhs, const MatrixSize &rhs);
+ EXPORTISMRMRD bool operator!=(const MatrixSize &lhs, const MatrixSize &rhs);
+ EXPORTISMRMRD bool operator==(const FieldOfView_mm &lhs, const FieldOfView_mm &rhs);
+ EXPORTISMRMRD bool operator!=(const FieldOfView_mm &lhs, const FieldOfView_mm &rhs);
+ EXPORTISMRMRD bool operator==(const EncodingSpace &lhs, const EncodingSpace &rhs);
+ EXPORTISMRMRD bool operator!=(const EncodingSpace &lhs, const EncodingSpace &rhs);
+ EXPORTISMRMRD bool operator==(const Limit &lhs, const Limit &rhs);
+ EXPORTISMRMRD bool operator!=(const Limit &lhs, const Limit &rhs);
+ EXPORTISMRMRD bool operator==(const EncodingLimits &lhs, const EncodingLimits &rhs);
+ EXPORTISMRMRD bool operator!=(const EncodingLimits &lhs, const EncodingLimits &rhs);
+ EXPORTISMRMRD bool operator==(const UserParameterLong &lhs, const UserParameterLong &rhs);
+ EXPORTISMRMRD bool operator!=(const UserParameterLong &lhs, const UserParameterLong &rhs);
+ EXPORTISMRMRD bool operator==(const UserParameterDouble &lhs, const UserParameterDouble &rhs);
+ EXPORTISMRMRD bool operator!=(const UserParameterDouble &lhs, const UserParameterDouble &rhs);
+ EXPORTISMRMRD bool operator==(const UserParameterString &lhs, const UserParameterString &rhs);
+ EXPORTISMRMRD bool operator!=(const UserParameterString &lhs, const UserParameterString &rhs);
+ EXPORTISMRMRD bool operator==(const UserParameters &lhs, const UserParameters &rhs);
+ EXPORTISMRMRD bool operator!=(const UserParameters &lhs, const UserParameters &rhs);
+ EXPORTISMRMRD bool operator==(const TrajectoryDescription &lhs, const TrajectoryDescription &rhs);
+ EXPORTISMRMRD bool operator!=(const TrajectoryDescription &lhs, const TrajectoryDescription &rhs);
+ EXPORTISMRMRD bool operator==(const AccelerationFactor &lhs, const AccelerationFactor &rhs);
+ EXPORTISMRMRD bool operator!=(const AccelerationFactor &lhs, const AccelerationFactor &rhs);
+ EXPORTISMRMRD bool operator==(const ParallelImaging &lhs, const ParallelImaging &rhs);
+ EXPORTISMRMRD bool operator!=(const ParallelImaging &lhs, const ParallelImaging &rhs);
+ EXPORTISMRMRD bool operator==(const Multiband &lhs, const Multiband &rhs);
+ EXPORTISMRMRD bool operator!=(const Multiband &lhs, const Multiband &rhs);
+ EXPORTISMRMRD bool operator==(const MultibandSpacing &lhs, const MultibandSpacing &rhs);
+ EXPORTISMRMRD bool operator!=(const MultibandSpacing &lhs, const MultibandSpacing &rhs);
+ EXPORTISMRMRD bool operator==(const Encoding &lhs, const Encoding &rhs);
+ EXPORTISMRMRD bool operator!=(const Encoding &lhs, const Encoding &rhs);
+ EXPORTISMRMRD bool operator==(const SequenceParameters &lhs, const SequenceParameters &rhs);
+ EXPORTISMRMRD bool operator!=(const SequenceParameters &lhs, const SequenceParameters &rhs);
+ EXPORTISMRMRD bool operator==(const WaveformInformation &lhs, const WaveformInformation &rhs);
+ EXPORTISMRMRD bool operator!=(const WaveformInformation &lhs, const WaveformInformation &rhs);
+ EXPORTISMRMRD bool operator==(const threeDimensionalFloat &lhs, const threeDimensionalFloat &rhs);
+ EXPORTISMRMRD bool operator!=(const threeDimensionalFloat &lhs, const threeDimensionalFloat &rhs);
+ EXPORTISMRMRD bool operator==(const MeasurementDependency &lhs, const MeasurementDependency &rhs);
+ EXPORTISMRMRD bool operator!=(const MeasurementDependency &lhs, const MeasurementDependency &rhs);
+ EXPORTISMRMRD bool operator==(const GradientDirection &lhs, const GradientDirection &rhs);
+ EXPORTISMRMRD bool operator!=(const GradientDirection &lhs, const GradientDirection &rhs);
+ EXPORTISMRMRD bool operator==(const Diffusion &lhs, const Diffusion &rhs);
+ EXPORTISMRMRD bool operator!=(const Diffusion &lhs, const Diffusion &rhs);
+
 
 /** @} */
 
-} // namespace ISMRMRD
+}
 
-#endif // ISMRMRDXML_H
+#endif //ISMRMRDXML_H


### PR DESCRIPTION
This PR bumps the build number of the conda package. 

The conda-feedstock package for PugiXML was actually a static library, which we depended on, but they decided to move to a shared library, but they did it without bumping the version number of the package. This will pull in this change and create a new build version for us. It is to reduce the downstream breakage in various packages where build strings are not pinned. 

See: https://github.com/conda-forge/pugixml-feedstock/pull/22

There will be a subsequent package to pull in a later version of PugiXML and rev the version of ISMRMRD. 