### PR TITLE
fix no mermaid diagram in pdf when build on readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,6 +1,6 @@
 # Read the Docs configuration file for Sphinx projects
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
-
+# See https://github.com/mgaitan/sphinxcontrib-mermaid/tree/master?tab=readme-ov-file#building-pdfs-on-readthedocsio for mermaid in pdf
 # Required
 version: 2
 
@@ -9,6 +9,10 @@ build:
   os: ubuntu-20.04
   tools:
     python: "3.9"
+    nodejs: "20"
+  jobs:
+    post_install:
+      - npm install -g @mermaid-js/mermaid-cli
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:


### PR DESCRIPTION
@hansenms Hi Michael, can you have a review? :)

Fix no mermaid diagram in pdf when building on readthedocs

The build of latex pdf works if mermaid-cli is installed, so tell readthedocs install mermaid-cli.

You can check session-protocol section of https://ismrmrd.readthedocs.io/_/downloads/en/stable/pdf/

