### PR TITLE
Fix nodiscard warning in meta.cpp

### DIFF
--- a/libsrc/meta.cpp
+++ b/libsrc/meta.cpp
@@ -23,7 +23,7 @@ namespace ISMRMRD {
             pugi::xml_node value = meta.child("value");
 
             if (!name || !value) {
-                std::runtime_error("Malformed metadata value");
+                throw std::runtime_error("Malformed metadata value");
             }
 
             while (value) {


### PR DESCRIPTION
### PR Description

I'm a member of the Microsoft vcpkg team, I am submitting this Pull Request to address the compilation warning triggered by the use of the `std::runtime_error` constructor on line 26 of `libsrc/meta.cpp`. This warning is issued by the MSVC compiler (C4834) due to the discarded return value of a function with the `[[nodiscard]]` attribute.

It's important to note that this warning does not exist in the released versions of Visual Studio but was introduced after the recent STL PR (https://github.com/microsoft/STL/pull/5174)). This change causes the compiler to issue a warning when the return value is discarded.

### Specific Change:
- Added the `throw` keyword to the `std::runtime_error` call in `meta.cpp`.

This change resolves the warning and ensures compatibility with the latest STL implementation. By adhering to the `[[nodiscard]]` attribute, this fix improves code quality and robustness.

Thank you for reviewing this PR! If there are any other changes or improvements needed, please feel free to let me know.