### PR TITLE
Fix some CMake Deprecation Warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.0...3.30)
 foreach(p
     CMP0025 # CMake 3.0 Compiler id for Apple Clang is now ``AppleClang``.
     CMP0042 # CMake 3.0 ``MACOSX_RPATH`` is enabled by default.
@@ -6,6 +6,7 @@ foreach(p
     CMP0054 # CMake 3.1 Only interpret ``if()`` arguments as variables or keywords when unquoted.
     CMP0056 # CMake 3.2 Honor link flags in ``try_compile()`` source-file signature.
     CMP0058 # CMake 3.3 Ninja requires custom command byproducts to be explicit.
+    CMP0167 # CMake 3.30 does not ship FindBoost
     )
   if(POLICY ${p})
     cmake_policy(SET ${p} NEW)

--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.0...3.30)
 project(ISMRMRD-C-EXAMPLE)
 
 # if building this example as a standalone project


### PR DESCRIPTION
Hello! Thanks for providing this nice library.
I had some trouble building the utilities on Fedora,
because the newer CMake shipping with that distribution is complaining about some things.

It turned out I actually just forgot to install boost-devel,
but I fixed the deprecation warnings first, so, here is a pull request! Hope it is helpful.

Best
Philip