### PR TITLE
i/i/waveform.h: pad struct ISMRMRD_WaveformHeader.

### DIFF
--- a/include/ismrmrd/waveform.h
+++ b/include/ismrmrd/waveform.h
@@ -26,6 +26,8 @@ extern "C" {
 typedef struct ISMRMRD_WaveformHeader
 {
     uint16_t version;
+    uint16_t pad1;
+    uint32_t pad2;
     /**< First unsigned int indicates the version */
     uint64_t flags;
     /**< bit field with flags */


### PR DESCRIPTION
Building ismrmrd on 32-bit aligned platforms results in build failures with the following symptoms:

	In file included from /build/reproducible-path/ismrmrd-1.14.3/libsrc/waveform.cpp:7:
	/build/reproducible-path/ismrmrd-1.14.3/include/ismrmrd/waveform.h:51:46: error: static assertion failed: ISMRMRD_WaveformHeader is not 40 bytes
	   51 | static_assert(sizeof(ISMRMRD_WaveformHeader) == 40, "ISMRMRD_WaveformHeader is not 40 bytes");
	      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
	/build/reproducible-path/ismrmrd-1.14.3/include/ismrmrd/waveform.h:51:46: note: the comparison reduces to '(36 == 40)'
	/build/reproducible-path/ismrmrd-1.14.3/include/ismrmrd/waveform.h:53:55: error: static assertion failed: ISMRMRD WaveformHeader flags offset is not correct
	   53 | static_assert(offsetof(ISMRMRD_WaveformHeader, flags) == 8, "ISMRMRD WaveformHeader flags offset is not correct");
	      |                                                       ^
	/build/reproducible-path/ismrmrd-1.14.3/include/ismrmrd/waveform.h:53:55: note: the comparison reduces to '(4 == 8)'

This change makes sure that the ISMRMRD_Waveform has the same size and elements offsets, be it on 64-bit or 32-bit aligned platforms, by explicitly padding the struct ISMRMRD_WaveformHeader where it was previously only implicitly padded by the compiler,

Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1119868